### PR TITLE
Reorganize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,6 @@ A collection of GitHub Actions meant to be reused by multiple VIP projects.
 
 ### Changelog
 
-Retrieves changelog data from the last closed Pull Request and publishes a changelog post to a given endpoint. By default it will post to https://vipinternalchangelog.wordpress.com when no endpoint is provided.
+Retrieves changelog data from the last closed Pull Request and publishes a changelog post to a given endpoint.
 
-For more info about the tool it uses under the hood, see: https://github.com/Automattic/vip-build-tools/#script-changelog
-
-#### Example
-
-```yaml
----
-
-name: My Workflow
-on:
-  push:
-    branches:
-      - master
-
-jobs:
-  changelog:
-    name: Changelog
-    needs: [deploy]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: Automattic/vip-actions/changelog@v1
-        with:
-          endpoint-token: ${{ secrets.CHANGELOG_POST_TOKEN }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-```
+[More info](changelog/README.md).

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,36 @@
+# Changelog
+
+This action retrieves changelog data from the last closed pull request and publishes a changelog post to the given endpoint. By default, it will post to https://vipinternalchangelog.wordpress.com.
+
+For more info about the tool it uses under the hood, see: https://github.com/Automattic/vip-build-tools/#script-changelog
+
+## Inputs
+
+  * `endpoint`: the endpoint to post the changelog; `https://public-api.wordpress.com/wp/v2/sites/vipinternalchangelog.wordpress.com/posts` by default;
+  * `endpoint-token`: the WordPress token required to post to the given `endpoint`. **Required**.
+  * `repo-token`: the GitHub token required to retrieve pull requests. By default, `github.token` is used. Please make sure that the provided token has the `pull-requests: read` permission.
+  * `status`: the status of the post to be published. Can be either `publish` (the default) or `draft`.
+  * `tag-id`: the ID of a tag to be added to the post, empty by default. Can be a comma-separated list of tag IDs.
+  * `link-to-pr`: whether to add a link to the pull request to the changelog post, `false` by default.
+
+#### Example
+
+```yaml
+name: My Workflow
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: Automattic/vip-actions/changelog@v1
+        with:
+          endpoint-token: ${{ secrets.CHANGELOG_POST_TOKEN }}
+          link-to-pr: 'true'
+```

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -24,7 +24,7 @@ inputs:
   link-to-pr:
     description: 'Wether to add a link to the Pull Request to the changelog post.'
     required: false
-    default: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -40,10 +40,10 @@ runs:
     - name: Publishes the changelog
       run: |
         php vendor/automattic/vip-build-tools/scripts/github-changelog.php \
-          --wp-endpoint=${{ inputs.endpoint }} \
-          --wp-status=${{ inputs.status }} \
-          --wp-tag-ids=${{ inputs.tag-id }} \
-          --link-to-pr=${{ inputs.link-to-pr }}
+          --wp-endpoint='${{ inputs.endpoint }}' \
+          --wp-status='${{ inputs.status }}' \
+          --wp-tag-ids='${{ inputs.tag-id }}' \
+          --link-to-pr='${{ inputs.link-to-pr }}'
       shell: bash
       env:
         CHANGELOG_POST_TOKEN: ${{ inputs.endpoint-token }}


### PR DESCRIPTION
This PR:
* adds the documentation about the Changelog action into `changelog/README.md`;
* adds a reference to `changelog/README.md` into the main `README.md`.
