### PR TITLE
Changelog: Exposes `start-marker` and `end-marker` options

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -12,6 +12,8 @@ For more info about the tool it uses under the hood, see: https://github.com/Aut
   * `status`: the status of the post to be published. Can be either `publish` (the default) or `draft`.
   * `tag-id`: the ID of a tag to be added to the post, empty by default. Can be a comma-separated list of tag IDs.
   * `link-to-pr`: whether to add a link to the pull request to the changelog post, `false` by default.
+  * `start-marker`: a string inside the PR description that marks the **start** of the changelog post. Defaults to `<h2>Changelog Description`.
+  * `end-marker`: a string inside the PR description that marks the **end** of the changelog post. Defaults to `<h2>`.
 
 #### Example
 

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -22,9 +22,17 @@ inputs:
     required: false
     default: ''
   link-to-pr:
-    description: 'Wether to add a link to the Pull Request to the changelog post.'
+    description: 'Whether to add a link to the Pull Request to the changelog post.'
     required: false
     default: 'false'
+  start-marker:
+    description: 'A string inside the PR description that marks the start of the changelog post.'
+    required: false
+    default: '<h2>Changelog Description'
+  end-marker:
+    description: 'A string inside the PR description that marks the end of the changelog post.'
+    required: false
+    default: '<h2>'
 runs:
   using: "composite"
   steps:
@@ -43,7 +51,9 @@ runs:
           --wp-endpoint='${{ inputs.endpoint }}' \
           --wp-status='${{ inputs.status }}' \
           --wp-tag-ids='${{ inputs.tag-id }}' \
-          --link-to-pr='${{ inputs.link-to-pr }}'
+          --link-to-pr='${{ inputs.link-to-pr }}' \
+          --start-marker='${{ inputs.start-marker }}' \
+          --end-marker='${{ inputs.end-marker }}'
       shell: bash
       env:
         CHANGELOG_POST_TOKEN: ${{ inputs.endpoint-token }}


### PR DESCRIPTION
Sometimes we need to write more detailed changelog posts, and the default markers may conflict with the text format we want. So this PR exposes the marker options as inputs so we can change them.

The following PR is an example of text that got skipped because of a `<h2>` at the beginning of the changelog text: 

https://a8c.slack.com/archives/CKUJZT08Y/p1655883105486269