### PR TITLE
Add reusable action for npm publishing

### DIFF
--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -1,0 +1,59 @@
+# Publish to npm
+
+This action makes it easy to publish to npm using GitHub Actions after running some light validation (e.g. `npm test`).
+
+The initial code was inspired by https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+## Inputs
+
+* `release_type`: the [npm version type (major|minor|patch)](https://docs.npmjs.com/cli/v8/commands/npm-version) we're releasing.
+
+* `NPM_TOKEN`: the npm token used to publish the package.
+
+## Example
+
+The following set up the release flow to be manually triggered from the Actions section.
+
+```yaml
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      # This is copied from npm-publish/action.yml
+      release_type:
+        description: 'The npm version type we are releasing.'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  publish:
+    name: Publish to npm
+    steps:
+      - uses: Automattic/vip-actions/npm-publish@v1
+        with:
+          release_type: ${{ inputs.release_type }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+The following triggers a release on every push to trunk (note: every release will be a patch update):
+
+```yaml
+name: Release
+on:
+  push:
+    branches:
+      - 'trunk'
+
+jobs:
+  publish:
+    name: Publish to npm
+    steps:
+      - uses: Automattic/vip-actions/npm-publish@v1
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```

--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -7,7 +7,6 @@ The initial code was inspired by https://help.github.com/actions/language-and-fr
 ## Inputs
 
 * `release_type`: the [npm version type (major|minor|patch)](https://docs.npmjs.com/cli/v8/commands/npm-version) we're releasing.
-
 * `NPM_TOKEN`: the npm token used to publish the package.
 
 ## Example
@@ -15,7 +14,7 @@ The initial code was inspired by https://help.github.com/actions/language-and-fr
 The following set up the release flow to be manually triggered from the Actions section.
 
 ```yaml
-name: Release
+name: npm publish
 on:
   workflow_dispatch:
     inputs:
@@ -40,10 +39,10 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
-The following triggers a release on every push to trunk (note: every release will be a patch update):
+The following triggers a release on every push to `trunk` (note: every release will be a patch update):
 
 ```yaml
-name: Release
+name: npm publish
 on:
   push:
     branches:

--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -6,12 +6,13 @@ The initial code was inspired by https://help.github.com/actions/language-and-fr
 
 ## Inputs
 
-* `release_type`: the [npm version type (major|minor|patch)](https://docs.npmjs.com/cli/v8/commands/npm-version) we're releasing.
-* `NPM_TOKEN`: the npm token used to publish the package.
+* `NPM_TOKEN`: (required) the npm token used to publish the package.
+* `npm-version-type`: (optional) the [npm version type (major|minor|patch)](https://docs.npmjs.com/cli/v8/commands/npm-version) we're publishing.
+* `node-version`: (options) the Node.js version to use for the Action
 
 ## Example
 
-The following set up the release flow to be manually triggered from the Actions section.
+The following sets up the publishing flow to be manually triggered from the Actions section:
 
 ```yaml
 name: npm publish
@@ -19,8 +20,8 @@ on:
   workflow_dispatch:
     inputs:
       # This is copied from npm-publish/action.yml
-      release_type:
-        description: 'The npm version type we are releasing.'
+      npm-version-type:
+        description: 'The npm version type we are publishing.'
         required: true
         type: choice
         default: 'patch'
@@ -33,13 +34,13 @@ jobs:
   publish:
     name: Publish to npm
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v1
+      - uses: Automattic/vip-actions/npm-publish
         with:
-          release_type: ${{ inputs.release_type }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm-version-type: ${{ inputs.npm-version-type }}
 ```
 
-The following triggers a release on every push to `trunk` (note: every release will be a patch update):
+The following triggers a publish on every push to `trunk` (note: every release will be a patch update since `npm-version-type` is not specified):
 
 ```yaml
 name: npm publish
@@ -52,7 +53,7 @@ jobs:
   publish:
     name: Publish to npm
     steps:
-      - uses: Automattic/vip-actions/npm-publish@v1
+      - uses: Automattic/vip-actions/npm-publish
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -3,8 +3,11 @@
 name: Publish package to npm
 description: This action automates various aspects of publishing a package to the npm registry including running tests, versioning, and tagging.
 inputs:
-  release_type:
-    description: 'The npm version type we are releasing.'
+  NPM_TOKEN:
+    description: 'The npm token used to publish the package.'
+    required: true
+  npm-version-type:
+    description: 'The npm version type we are publishing.'
     required: true
     type: choice
     default: 'patch'
@@ -12,9 +15,10 @@ inputs:
       - patch
       - minor
       - major
-  NPM_TOKEN:
-    description: 'The npm token used to publish the package.'
-    required: true
+  node-version:
+    description: 'The Node.js version to use in the Action'
+    required: false
+    default: 'lts/*'
 
 runs:
   using: "composite"
@@ -25,7 +29,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: ${{ inputs.node-version }}
         registry-url: https://registry.npmjs.org/
 
     - name: git config
@@ -36,6 +40,6 @@ runs:
 
     - name: Validate & Publish
       shell: bash
-      run: ./bin/publish.sh -t ${{ inputs.release_type }}
+      run: ./bin/publish.sh -t ${{ inputs.npm-version-type }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -1,0 +1,41 @@
+---
+
+name: Publish package to npm
+description: This action automates various aspects of publishing a package to the npm registry including running tests, versioning, and tagging.
+inputs:
+  release_type:
+    description: 'The npm version type we are releasing.'
+    required: true
+    type: choice
+    default: 'patch'
+    options:
+      - patch
+      - minor
+      - major
+  NPM_TOKEN:
+    description: 'The npm token used to publish the package.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        registry-url: https://registry.npmjs.org/
+
+    - name: git config
+      shell: bash
+      run: |
+        git config --global user.name "WordPress VIP Bot"
+        git config --global user.email "<22917138+wpcomvip-bot@users.noreply.github.com>"
+
+    - name: Validate & Publish
+      shell: bash
+      run: ./bin/publish.sh -t ${{ inputs.release_type }}
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -o errexit   # exit on error
+set -o errtrace  # exit on error within function/sub-shell
+set -o nounset   # error on undefined vars
+set -o pipefail  # error if piped command fails
+
+# Default variables
+RELEASE_TYPE=
+MAIN_BRANCH="trunk"
+
+echo_title() {
+	echo ""
+	echo "== $1 =="
+}
+
+while getopts ":t:" option;
+do
+	case $option in
+		# npm major/minor/patch
+		t) RELEASE_TYPE=$OPTARG ;;
+
+		\?) echo "Error: Invalid param / option specified"
+			exit 199 ;;
+   esac
+done
+
+# Validate release type value
+if [ "$RELEASE_TYPE" != "major" ] && [ "$RELEASE_TYPE" != "minor" ] && [ "$RELEASE_TYPE" != "patch" ]; then
+	echo "❌ Invalid release type specified. Please make sure the -t flag is one of major/minor/patch."
+	exit 200
+fi
+
+# Fetch some basic package information
+echo_title "Fetching local package info"
+LOCAL_NAME=$(node -p "require('./package.json').name")
+LOCAL_VERSION=$(node -p "require('./package.json').version")
+LOCAL_BRANCH=$(git branch --show-current)
+REMOTE_VERSION=$(npm view "$LOCAL_NAME" version)
+echo "✅ Found $LOCAL_NAME $LOCAL_VERSION on branch $LOCAL_BRANCH"
+echo "✅ Published version is $REMOTE_VERSION"
+echo "✅ Will publish new $RELEASE_TYPE release"
+
+# Validate npm is logged in and ready
+echo_title "Checking npm auth"
+if ! NPM_USER=$( npm whoami ); then
+	echo "❌ npm cli is not authenticated. Please make sure you're logged in or NPM_TOKEN is set."
+	exit 201
+fi
+echo "✅ Logged in as $NPM_USER and ready to publish"
+
+# Validate current branch
+echo_title "Checking branch"
+# TODO: add support for release/** branch via [ ! "$LOCAL_BRANCH" == "$RELEASE_BRANCH_PATTERN" ] -- will need to add version checking support as well
+if [ "$LOCAL_BRANCH" != "$MAIN_BRANCH" ]; then
+	echo "❌ You can only publish from the '$MAIN_BRANCH' branch. Please switch branches and try again."
+	exit 202
+fi
+echo "✅ On a valid release branch ($LOCAL_BRANCH)"
+
+# Validate no uncommitted changes.
+# Shouldn't happen in CI but protects against local runs.
+echo_title "Checking for local changes"
+if ! git diff-index --quiet HEAD --; then
+	echo "❌ Working directory has uncommitted changes; please clean up before proceeding."
+	exit 203
+fi
+echo "✅ No local changes found"
+
+### TODO=====================
+# Validate version not published
+# Need a cleaner way to fetch published versions
+#echo_title "Checking version"
+#IS_VERSION_PUBLISHED=$(npm info . versions --json | grep -q "\"$LOCAL_VERSION\"")
+#echo $IS_VERSION_PUBLISHED
+### TODO=====================
+
+# Install
+echo_title "npm ci"
+npm ci
+echo "✅ Clean install looks good"
+
+# Test
+echo_title "npm test"
+npm test
+echo "✅ Tests look good"
+
+### DEBUG=====================
+### echo "EARLY EXIT BEFORE PUBLISH"
+### exit 299
+### DEBUG=====================
+
+### TODO=====================
+# Confirm y/n (if running locally)
+### TODO=====================
+
+# Publish with Dry Run
+echo_title "npm publish (dry-run)"
+npm publish --access public --dry-run
+echo "✅ Dry run looks good"
+
+# npm version bump + git tag
+echo_title "npm version"
+NEW_RELEASE_VERSION=$( npm version "$RELEASE_TYPE" -m "Publishing new $RELEASE_TYPE version: %s" )
+echo "✅ Bumped version to $NEW_RELEASE_VERSION and created new tag"
+
+# git push
+echo_title "git push"
+git push && git push --tags
+echo "✅ Pushed version bump and tags"
+
+# Publish
+echo_title "npm publish"
+npm publish --access public
+echo "✅ Successfully published new '$RELEASE_TYPE' release for $LOCAL_NAME as $NEW_RELEASE_VERSION"
+
+# Version bump to dev
+# Not needed for release branches so we only do on the main branch
+if [ "$LOCAL_BRANCH" == "$MAIN_BRANCH" ]; then
+	echo_title "npm version (to next dev)"
+
+	NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
+	if [ "$RELEASE_TYPE" == "major" ]; then
+		NEXT_LOCAL_DEV_VERSION_TYPE="preminor"
+	elif [ "$RELEASE_TYPE" == "minor" ]; then
+		NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
+	fi
+
+	NEXT_LOCAL_DEV_VERSION=$( npm version --no-git-tag-version --preid "dev" "$NEXT_LOCAL_DEV_VERSION_TYPE" )
+	git add -u
+	git commit -m "Bump to next $NEXT_LOCAL_DEV_VERSION_TYPE: ($NEXT_LOCAL_DEV_VERSION)"
+	git push
+
+	NEXT_LOCAL_DEV_VERSION=$(node -p "require('./package.json').version")
+
+	echo "✅ Bumped local version to next $NEXT_LOCAL_DEV_VERSION_TYPE: $NEXT_LOCAL_DEV_VERSION"
+fi

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -6,7 +6,7 @@ set -o nounset   # error on undefined vars
 set -o pipefail  # error if piped command fails
 
 # Default variables
-RELEASE_TYPE=
+NPM_VERSION_TYPE=
 MAIN_BRANCH="$(LC_ALL=C git remote show origin | awk '/HEAD branch/ {print $NF}')"
 
 echo_title() {
@@ -18,7 +18,7 @@ while getopts ":t:" option;
 do
 	case $option in
 		# npm major/minor/patch
-		t) RELEASE_TYPE=$OPTARG ;;
+		t) NPM_VERSION_TYPE=$OPTARG ;;
 
 		\?) echo "Error: Invalid param / option specified"
 			exit 199 ;;
@@ -26,7 +26,7 @@ do
 done
 
 # Validate release type value
-if [ "$RELEASE_TYPE" != "major" ] && [ "$RELEASE_TYPE" != "minor" ] && [ "$RELEASE_TYPE" != "patch" ]; then
+if [ "$NPM_VERSION_TYPE" != "major" ] && [ "$NPM_VERSION_TYPE" != "minor" ] && [ "$NPM_VERSION_TYPE" != "patch" ]; then
 	echo "❌ Invalid release type specified. Please make sure the -t flag is one of major/minor/patch."
 	exit 200
 fi
@@ -39,7 +39,7 @@ LOCAL_BRANCH=$(git branch --show-current)
 REMOTE_VERSION=$(npm view "$LOCAL_NAME" version)
 echo "✅ Found $LOCAL_NAME $LOCAL_VERSION on branch $LOCAL_BRANCH"
 echo "✅ Published version is $REMOTE_VERSION"
-echo "✅ Will publish new $RELEASE_TYPE release"
+echo "✅ Will publish new $NPM_VERSION_TYPE release"
 
 # Validate npm is logged in and ready
 echo_title "Checking npm auth"
@@ -101,8 +101,8 @@ echo "✅ Dry run looks good"
 
 # npm version bump + git tag
 echo_title "npm version"
-NEW_RELEASE_VERSION=$( npm version "$RELEASE_TYPE" -m "Publishing new $RELEASE_TYPE version: %s" )
-echo "✅ Bumped version to $NEW_RELEASE_VERSION and created new tag"
+NEW_VERSION=$( npm version "$NPM_VERSION_TYPE" -m "Publishing new $NPM_VERSION_TYPE version: %s" )
+echo "✅ Bumped version to $NEW_VERSION and created new tag"
 
 # git push
 echo_title "git push"
@@ -112,7 +112,7 @@ echo "✅ Pushed version bump and tags"
 # Publish
 echo_title "npm publish"
 npm publish --access public
-echo "✅ Successfully published new '$RELEASE_TYPE' release for $LOCAL_NAME as $NEW_RELEASE_VERSION"
+echo "✅ Successfully published new '$NPM_VERSION_TYPE' release for $LOCAL_NAME as $NEW_VERSION"
 
 # Version bump to dev
 # Not needed for release branches so we only do on the main branch
@@ -120,9 +120,9 @@ if [ "$LOCAL_BRANCH" == "$MAIN_BRANCH" ]; then
 	echo_title "npm version (to next dev)"
 
 	NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
-	if [ "$RELEASE_TYPE" == "major" ]; then
+	if [ "$NPM_VERSION_TYPE" == "major" ]; then
 		NEXT_LOCAL_DEV_VERSION_TYPE="preminor"
-	elif [ "$RELEASE_TYPE" == "minor" ]; then
+	elif [ "$NPM_VERSION_TYPE" == "minor" ]; then
 		NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
 	fi
 

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -76,14 +76,16 @@ echo "✅ No local changes found"
 ### TODO=====================
 
 # Install
-echo_title "npm ci"
-npm ci
-echo "✅ Clean install looks good"
+echo_title "npm ci + test"
 
-# Test
-echo_title "npm test"
-npm test
-echo "✅ Tests look good"
+# Install dependencies but skip pre/post scripts since our auth token is in place
+npm ci --ignore-scripts
+
+# Run scripts + tests without auth token to prevent malicious access
+NODE_AUTH_TOKEN= npm rebuild
+NODE_AUTH_TOKEN= npm run prepare --if-present
+NODE_AUTH_TOKEN= npm test
+echo "✅ npm install + npm test look good"
 
 ### DEBUG=====================
 ### echo "EARLY EXIT BEFORE PUBLISH"

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -106,7 +106,7 @@ echo "✅ Bumped version to $NEW_RELEASE_VERSION and created new tag"
 
 # git push
 echo_title "git push"
-git push && git push --tags
+git push --follow-tags
 echo "✅ Pushed version bump and tags"
 
 # Publish

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -7,7 +7,7 @@ set -o pipefail  # error if piped command fails
 
 # Default variables
 RELEASE_TYPE=
-MAIN_BRANCH="trunk"
+MAIN_BRANCH="$(LC_ALL=C git remote show origin | awk '/HEAD branch/ {print $NF}')"
 
 echo_title() {
 	echo ""


### PR DESCRIPTION
The action makes it easy to publish to npm using GitHub Actions after running some light validation (e.g. `npm test`).

### Possible future improvements:

- Validate that the version we're attempting to release isn't already published.
- Automatically create GitHub Release with auto-generated changelog.
- Add a confirmation step if running the script locally.
- Add support for creating release branches (for minor versions) and the ability to release from them. Or alternatively, run the Action against a tag.

### To Test Locally

1. Checkout the vip-actions repo and this branch.
1. Find the path for this script using `pwd`
2. `cd` to package you want to publish (you can also just create a test package via `npm init` and give it a unique name like `<username>-npm-publish-test`)
4. `/path/to/vip-actions/npm-publish/bin/publish.sh -t patch`