### PR TITLE
npm-publish: Prefix script w/ github.action_path

### DIFF
--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -40,6 +40,8 @@ runs:
 
     - name: Validate & Publish
       shell: bash
-      run: ./bin/publish.sh -t ${{ inputs.npm-version-type }}
+      # Must use `github.action_path` since the script 
+      # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
+      run: ${{ github.action_path }}/bin/publish.sh -t ${{ inputs.npm-version-type }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -40,8 +40,8 @@ runs:
 
     - name: Validate & Publish
       shell: bash
-      # Must use `github.action_path` since the script 
-      # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
+      # Must use `github.action_path` since the script is located in a separate checkout than the calling repo.
+      # @see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
       run: ${{ github.action_path }}/bin/publish.sh -t ${{ inputs.npm-version-type }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}


### PR DESCRIPTION
`actions/checkout` clones the calling repo not `vip-actions`. However, our publish script is located in a separate location and this can lead to a `line 1: ./bin/publish.sh: No such file or directory` error.

We switch to use ${{ github.action_path }} to reference the location and avoid the error.

See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun

The alternate approach is to download the script and execute (e.g. https://stackoverflow.com/a/72144907)