### PR TITLE
Fix instructions missing ref for actions

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -29,7 +29,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: Automattic/vip-actions/changelog@v1
+      - uses: Automattic/vip-actions/changelog@trunk
         with:
           endpoint-token: ${{ secrets.CHANGELOG_POST_TOKEN }}
           link-to-pr: 'true'

--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -58,7 +58,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: Automattic/vip-actions/npm-publish
+      - uses: Automattic/vip-actions/npm-publish@trunk
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           npm-version-type: ${{ inputs.npm-version-type }}
@@ -78,7 +78,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: Automattic/vip-actions/npm-publish
+      - uses: Automattic/vip-actions/npm-publish@trunk
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```


### PR DESCRIPTION
## Description

Github Actions require ref - they're mandatory. This PR updates the documentation to include the refs. Also, the `@v1` ref does not exist in this repo so it was replaced with `@trunk`