### PR TITLE
Add troubleshooting guide for permissions issues for dependabot auto merge

### DIFF
--- a/dependabot-auto-merge/README.md
+++ b/dependabot-auto-merge/README.md
@@ -91,4 +91,4 @@ This is because your repository has additional security feature to it. To fix th
 2. Under Branch protection rules, find your default branch and press Edit. We assume it's `trunk`.
 3. Untick `Restrict who can push to matching branches`
 
-We're currently unsure if this is a safe thing to do. However, there's currentlyno way to put an exception for `dependabot` and `github-actions`
+We're currently unsure if this is a safe thing to do. However, there's currently no way to put an exception for `dependabot` and `github-actions`

--- a/dependabot-auto-merge/README.md
+++ b/dependabot-auto-merge/README.md
@@ -81,3 +81,14 @@ updates:
     open-pull-requests-limit: 15
 ```
 
+### Troubleshooting
+
+#### I'm getting an error "Pull request User is not authorized for this protected branch"
+
+This is because your repository has additional security feature to it. To fix this:
+
+1. Go to Settings > Branches on the left navbar
+2. Under Branch protection rules, find your default branch and press Edit. We assume it's `trunk`.
+3. Untick `Restrict who can push to matching branches`
+
+We're currently unsure if this is a safe thing to do. However, there's currentlyno way to put an exception for `dependabot` and `github-actions`


### PR DESCRIPTION
## Description

In certain repos, we could get the error `"Pull request User is not authorized for this protected branch"`.

This PR show how to troubleshoot this error. The current fix suggested by this PR isn't actually ideal as we're unticking all the restrictions, but I couldn't find a better way.