### PR TITLE
Add Dependaban action to flag dependencies with install scripts

### DIFF
--- a/dependaban/README.md
+++ b/dependaban/README.md
@@ -26,7 +26,7 @@ jobs:
     name: Dependaban
     runs-on: ubuntu-latest
     permissions:
-      contests: read
+      contents: read
     steps:
       - uses: Automattic/vip-actions/dependaban@trunk
 ```

--- a/dependaban/README.md
+++ b/dependaban/README.md
@@ -1,0 +1,32 @@
+# Dependaban
+
+This action checks for NPM dependencies that rely on install scripts and fails if any are present. By running this action on pull requests, projects can use `npm install --ignore-scripts` with confidence. It uses [`can-i-ignore-scripts`](https://github.com/naugtur/can-i-ignore-scripts) under the hood.
+
+## Why is this useful?
+
+NPM packages can use scripts like `preinstall` and `postinstall` to run arbitrary code (huge security risk!) or build binaries that work on one computer but not on another (not portable!).
+
+## Inputs
+
+- `skip-scripts-check`: Set to `"true"` to disable the check. Default: `"false"`
+
+## Example
+
+```yaml
+name: My Workflow
+on:
+  pull_request:
+  push:
+    branches:
+      - trunk
+  workflow_dispatch:
+
+jobs:
+  dependaban:
+    name: Dependaban
+    runs-on: ubuntu-latest
+    permissions:
+      contests: read
+    steps:
+      - uses: Automattic/vip-actions/dependaban@trunk
+```

--- a/dependaban/action.yml
+++ b/dependaban/action.yml
@@ -24,6 +24,6 @@ runs:
         cache: npm
 
     - name: Run can-i-ignore-scripts check
-      if: inputs.skip-scripts-check != "true"
+      if: ${{ inputs.skip-scripts-check != 'true' }}
       run: ${{ github.action_path }}/bin/can-i-ignore-scripts.sh
       shell: bash

--- a/dependaban/action.yml
+++ b/dependaban/action.yml
@@ -1,0 +1,29 @@
+---
+
+name: Dependaban
+description: "This action checks for dependencies that rely on install scripts"
+
+inputs:
+  skip-scripts-check:
+    description: "Skip the check for postinstall scripts (default: false)"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+
+    - name: Set up Node.js envirtonment
+      uses: actions/setup-node@v3
+      with:
+        node-version: "lts/*"
+        cache: npm
+
+    - name: Run can-i-ignore-scripts check
+      if: inputs.skip-scripts-check != "true"
+      run: ${{ github.action_path }}/bin/can-i-ignore-scripts.sh
+      shell: bash

--- a/dependaban/bin/can-i-ignore-scripts.sh
+++ b/dependaban/bin/can-i-ignore-scripts.sh
@@ -3,7 +3,7 @@
 # Print output and save to variable for inspection. We need to inspect because
 # it always exits with zero.
 # https://github.com/naugtur/can-i-ignore-scripts/pull/25
-CHECK_OUTPUT="$(npx can-i-ignore-scripts | tee /dev/stderr)"
+CHECK_OUTPUT="$(npx can-i-ignore-scripts@0.1.9 | tee /dev/stderr)"
 
 if printf "%s" "$CHECK_OUTPUT" | grep -qE '^\[ +(keep|check\?) +\]'; then
 	echo "Non-ignorable install scripts found!"

--- a/dependaban/bin/can-i-ignore-scripts.sh
+++ b/dependaban/bin/can-i-ignore-scripts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Print output and save to variable for inspection. We need to inspect because
+# it always exits with zero.
+# https://github.com/naugtur/can-i-ignore-scripts/pull/25
+CHECK_OUTPUT="$(npx can-i-ignore-scripts | tee /dev/stderr)"
+
+if printf "%s" "$CHECK_OUTPUT" | grep -qE '^\[ +(keep|check\?) +\]'; then
+	echo "Non-ignorable install scripts found!"
+	exit 1
+fi


### PR DESCRIPTION
Add "Dependaban" action to flag dependencies with install scripts. Uses [`can-i-ignore-scripts`](https://github.com/naugtur/can-i-ignore-scripts) under the hood. 

With this action in place, a project can safely move to using `--ignore-scripts`.