### PR TITLE
Add Node.js setup reusable action

### DIFF
--- a/nodejs-setup/README.md
+++ b/nodejs-setup/README.md
@@ -1,0 +1,38 @@
+# Node.js setup
+
+This action (composite workflow) reduces boilerplate in your action by performing Node.js setup and installing dependencies—with a solid approach to caching that speeds up your workflows.
+
+## Inputs
+
+- `node-version-file`: Set to the file containing your preferred Node.js version (e.g., `.nvmrc` or `.node-version`).
+- `node-version`: Set to a valid semver referencing your preferred Node.js version (e.g., `18.13`).
+
+One of `node-version` or `node-version-file` is required. Do not provide both.
+
+## Example
+
+```yaml
+name: My Workflow
+on:
+  pull_request:
+  push:
+    branches:
+      - trunk
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup and install
+        uses: Automattic/vip-actions/nodejs-setup@trunk
+        with:
+          node-version-file: .nvmrc
+
+      - name: Run linter
+        run: npm run lint
+```
+

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -1,0 +1,40 @@
+---
+
+name: Node.js setup and install
+description: This composite action performs Node.js setup and install with good caching defaults
+
+inputs:
+  node-version:
+    description: "Node.js version (e.g., 18.13.0) for set up"
+    required: false
+  node-version-file:
+    description: "Node.js version file (e.g., .nvmrc) for set up"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+
+    - name: Set up Node.js environment using supplied Node.js version
+      id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+        cache: npm
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      id: cache-node-modules
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+
+    - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      run: npm ci
+      shell: bash


### PR DESCRIPTION
Add a callable composite workflow that can be used as a step in other GitHub Actions. This reduces boilerplate, standardizes, and provides better default caching for Node.js workflows.