### PR TITLE
Add: Common GH action to push JUNIT XML results to New Relic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.vscode

--- a/junit-newrelic-processor/Dockerfile
+++ b/junit-newrelic-processor/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.10
 
 # install libs to process and push xml to newrelic
-RUN apk update && \
-    apk add xmlstarlet curl bash sudo
+RUN apk add --no-cache --update xmlstarlet curl bash sudo
 
 # install newrelic cli
 RUN curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash

--- a/junit-newrelic-processor/Dockerfile
+++ b/junit-newrelic-processor/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.10
+
+# install libs to process and push xml to newrelic
+RUN apk update && \
+    apk add xmlstarlet curl bash sudo
+
+# install newrelic cli
+RUN curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash
+
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN ["chmod", "+x", "/entrypoint.sh"]
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/junit-newrelic-processor/README.md
+++ b/junit-newrelic-processor/README.md
@@ -1,0 +1,24 @@
+# JUnit NewRelic Processor
+
+A Github Action to process Junit XML results and push them to NewRelic with as a custom event "TestRun".
+
+NewRelic already has an inbuilt method to push "TestRun" custom event. The CLI method to do it is `newrelic reporting junit --path <testResults.XML>`. However, once the test results are pushed into NewRelic, they do not have any association with the source or the event that triggered those test cases.
+
+This action makes a few changes to the results XML file before feeding it to NewRelic to maintain the relationship between CI Event and the Tests that were executed during workflow.
+
+## Inputs
+
+| Key                 | Required | Default | Description |
+| ------------------- | -------- | ------- | ----------- |
+| `accountId`         | **yes**  | -       | The account to post test run results to. This could also be a subaccount. |
+| `region`            | no       | US      | The region the account belongs to. |
+| `ingestLicenseKey` | **yes**  | -       | Your New Relic [License key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) used for data ingest. |
+| `testOutputPath`    | **yes**  | -       | The path to the JUnit output file. |
+| `ghEventType`    | **no**  | ${{ github.event_name }}       | Type of event that triggered workflow. |
+| `ghEventBranchName`    | **no**  | ${{ github.ref }}       | Name of branch that triggered the workflow. |
+
+## Processing
+The `ghEventType` and `ghEventBranchName` are added to each test case in the junit xml file as "attributes". These attributes are saved in NewRelic as the columns in the event data and they can be used to query the results and build dashboard for test observability in the CI systems.
+
+## Credit
+This action is heavily inspired by New Relic's own action: https://github.com/newrelic/junit-reporter-action/blob/main/README.md

--- a/junit-newrelic-processor/README.md
+++ b/junit-newrelic-processor/README.md
@@ -1,6 +1,6 @@
 # JUnit NewRelic Processor
 
-A Github Action to process Junit XML results and push them to NewRelic with as a custom event "TestRun".
+A Github Action to process JUnit XML results and push them to NewRelic as a custom event named "TestRun".
 
 NewRelic already has an inbuilt method to push "TestRun" custom event. The CLI method to do it is `newrelic reporting junit --path <testResults.XML>`. However, once the test results are pushed into NewRelic, they do not have any association with the source or the event that triggered those test cases.
 

--- a/junit-newrelic-processor/README.md
+++ b/junit-newrelic-processor/README.md
@@ -8,17 +8,20 @@ This action makes a few changes to the results XML file before feeding it to New
 
 ## Inputs
 
-| Key                 | Required | Default | Description |
-| ------------------- | -------- | ------- | ----------- |
-| `accountId`         | **yes**  | -       | The account to post test run results to. This could also be a subaccount. |
-| `region`            | no       | US      | The region the account belongs to. |
-| `ingestLicenseKey` | **yes**  | -       | Your New Relic [License key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/) used for data ingest. |
-| `testOutputPath`    | **yes**  | -       | The path to the JUnit output file. |
-| `ghEventType`    | **no**  | ${{ github.event_name }}       | Type of event that triggered workflow. |
-| `ghEventBranchName`    | **no**  | ${{ github.ref }}       | Name of branch that triggered the workflow. |
+| Key  | Required | Default | Description |
+| ------------- | ------------- | ------------- | ------------- |
+| NEW_RELIC_INGEST_LICENSE_KEY  | Yes  | None  | Your New Relic Ingest License key.  |
+| NEW_RELIC_ACCOUNT_ID  | Yes  | None  | Your New Relic account ID. Custom events representing your test run will be posted to this account.  |
+| NEW_RELIC_REGION  | No  | US  | The geographical region for your New Relic account - US or EU. Default: US  |
+| NEW_RELIC_TEST_OUTPUT_PATH  | Yes  | None  | The path to the JUnit output file.  |
+| GITHUB_EVENT_TYPE  | No  | `github.event.name`  | The GitHub event type that triggered the workflow, eg., pull_request, push. Default: github.event_name  |
+| GITHUB_EVENT_BRANCH  | No  | `github.ref_name`  | The branch name for the GitHub event that triggered the workflow. Default: github.ref_name  |
+| GITHUB_REPOSITORY  | No  | `github.repository`  | Name of organisation and repo of the project in the format `organisation/repository`  |
+| GITHUB_SHA  | No  | Commit that triggered the test run  | `github.sha`  |
+| GITHUB_PR_NUMBER  | No  | `github.event.number`  | Pull request number  |
 
 ## Processing
-The `ghEventType` and `ghEventBranchName` are added to each test case in the junit xml file as "attributes". These attributes are saved in NewRelic as the columns in the event data and they can be used to query the results and build dashboard for test observability in the CI systems.
+The above mentioned attributes are added to the standard JUNIT XML file to create correlation between the test run and the CI before they are pushed to New Relic.
 
 ## Credit
 This action is heavily inspired by New Relic's own action: https://github.com/newrelic/junit-reporter-action/blob/main/README.md

--- a/junit-newrelic-processor/action.yaml
+++ b/junit-newrelic-processor/action.yaml
@@ -1,0 +1,46 @@
+name: 'JUNIT New Relic Processor'
+description: 'Process JUnit XML output and send to New Relic'
+inputs:
+  NEW_RELIC_INGEST_LICENSE_KEY:
+    description: 'Your New Relic Ingest License key.'
+    required: true
+  NEW_RELIC_ACCOUNT_ID:
+    description: 'Your New Relic account ID. Custom events representing your test run will be posted to this account.'
+    required: true
+  NEW_RELIC_REGION:
+    description: 'The geographical region for your New Relic account - US or EU. Default: US'
+    required: false
+    default: US
+  NEW_RELIC_TEST_OUTPUT_PATH:
+    description: 'The path to the JUnit output file.'
+    required: true
+  GITHUB_EVENT_TYPE:
+    description: 'The GitHub event type that triggered the workflow, eg., pull_request, push. Default: github.event_name'
+    required: false
+    default: ${{ github.event_name }}
+  GITHUB_EVENT_BRANCH:
+    description: 'The branch name for the GitHub event that triggered the workflow. Default: github.ref_name'
+    required: false
+    default: ${{ github.ref_name }}
+  GITHUB_REPOSITORY:
+    description: 'Name of organisation and repo of the project'
+    required: true
+  GITHUB_SHA:
+    description: 'Commit that triggered the test run'
+    required: false
+  GITHUB_PR_NUMBER:
+    description: 'Pull request number'
+    required: false
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    NEW_RELIC_INGEST_LICENSE_KEY: ${{ inputs.NEW_RELIC_INGEST_LICENSE_KEY }}
+    NEW_RELIC_ACCOUNT_ID: ${{ inputs.NEW_RELIC_ACCOUNT_ID }}
+    NEW_RELIC_REGION: ${{ inputs.NEW_RELIC_REGION }}
+    NEW_RELIC_TEST_OUTPUT_PATH: ${{ inputs.NEW_RELIC_TEST_OUTPUT_PATH }}
+    GITHUB_EVENT_TYPE: ${{ inputs.GITHUB_EVENT_TYPE }}
+    GITHUB_EVENT_BRANCH: ${{ inputs.GITHUB_EVENT_BRANCH }}
+    GITHUB_REPOSITORY: ${{ inputs.GITHUB_REPOSITORY }}
+    GITHUB_SHA: ${{ inputs.GITHUB_SHA }}
+    GITHUB_PR_NUMBER: ${{ inputs.GITHUB_PR_NUMBER }}

--- a/junit-newrelic-processor/action.yaml
+++ b/junit-newrelic-processor/action.yaml
@@ -18,10 +18,18 @@ inputs:
     description: 'The GitHub event type that triggered the workflow, eg., pull_request, push. Default: github.event_name'
     required: false
     default: ${{ github.event_name }}
-  GITHUB_EVENT_BRANCH:
-    description: 'The branch name for the GitHub event that triggered the workflow. Default: github.ref_name'
+  GITHUB_PUSH_BRANCH:
+    description: 'Github branch in the event of push. Default: github.ref_name'
     required: false
     default: ${{ github.ref_name }}
+  GITHUB_PULL_REQUEST_BASE_BRANCH:
+    description: 'Github base branch in the event of pull_request. Default: github.base_ref'
+    required: false
+    default: ${{ github.base_ref }}
+  GITHUB_PULL_REQUEST_HEAD_BRANCH:
+    description: 'Github head branch in the event of pull_request. Default: github.head_ref'
+    required: false
+    default: ${{ github.head_ref }}
   GITHUB_REPOSITORY:
     description: 'Name of organisation and repo of the project'
     required: false
@@ -32,6 +40,7 @@ inputs:
   GITHUB_PR_NUMBER:
     description: 'Pull request number'
     required: false
+    default: ${{ github.event.number }}
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -41,7 +50,9 @@ runs:
     NEW_RELIC_REGION: ${{ inputs.NEW_RELIC_REGION }}
     NEW_RELIC_TEST_OUTPUT_PATH: ${{ inputs.NEW_RELIC_TEST_OUTPUT_PATH }}
     GITHUB_EVENT_TYPE: ${{ inputs.GITHUB_EVENT_TYPE }}
-    GITHUB_EVENT_BRANCH: ${{ inputs.GITHUB_EVENT_BRANCH }}
+    GITHUB_PUSH_BRANCH: ${{ inputs.GITHUB_PUSH_BRANCH }}
     GITHUB_REPOSITORY: ${{ inputs.GITHUB_REPOSITORY }}
     GITHUB_SHA: ${{ inputs.GITHUB_SHA }}
     GITHUB_PR_NUMBER: ${{ inputs.GITHUB_PR_NUMBER }}
+    GITHUB_PULL_REQUEST_HEAD_BRANCH: ${{ inputs.GITHUB_PULL_REQUEST_HEAD_BRANCH }}
+    GITHUB_PULL_REQUEST_BASE_BRANCH: ${{ inputs.GITHUB_PULL_REQUEST_BASE_BRANCH }}

--- a/junit-newrelic-processor/action.yaml
+++ b/junit-newrelic-processor/action.yaml
@@ -24,7 +24,8 @@ inputs:
     default: ${{ github.ref_name }}
   GITHUB_REPOSITORY:
     description: 'Name of organisation and repo of the project'
-    required: true
+    required: false
+    default: ${{ github.repository }}
   GITHUB_SHA:
     description: 'Commit that triggered the test run'
     required: false

--- a/junit-newrelic-processor/entrypoint.sh
+++ b/junit-newrelic-processor/entrypoint.sh
@@ -26,6 +26,14 @@ xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
 xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
   --type attr -n "github_pr_number" -v "$GH_PR_NUMBER" ${NEW_RELIC_TEST_OUTPUT_PATH}
 
+# Add PR URL if it's a PR
+if [[ $GH_EVENT == "pull_request" ]]; then
+  GH_PR_URL="https://github.com/${GH_PROJECT}/pulls/${GH_PR_NUMBER}"
+
+  xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
+    --type attr -n "github_pr_url" -v "$GH_PR_URL" ${NEW_RELIC_TEST_OUTPUT_PATH}
+fi
+
 # use newrelic cli to send the junit report to newrelic
 result=$(newrelic reporting junit \
   --accountId "${NEW_RELIC_ACCOUNT_ID}" \

--- a/junit-newrelic-processor/entrypoint.sh
+++ b/junit-newrelic-processor/entrypoint.sh
@@ -52,7 +52,9 @@ result=$(newrelic reporting junit \
 exitStatus=$?
 
 if [ $exitStatus -ne 0 ]; then
-  echo "::error:: $result"
+  echo "::error:: Unable to push results to New Relic. Exiting with: $result"
+else
+  echo "::success:: Successfully uploaded results to New Relic"
 fi
 
 exit $exitStatus

--- a/junit-newrelic-processor/entrypoint.sh
+++ b/junit-newrelic-processor/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+export NEW_RELIC_API_KEY=dummy_key
+export NEW_RELIC_REGION=${NEW_RELIC_REGION}
+export NEW_RELIC_LICENSE_KEY=${NEW_RELIC_INGEST_LICENSE_KEY}
+
+export GH_EVENT=${GITHUB_EVENT_TYPE}
+export GH_BRANCH=${GITHUB_EVENT_BRANCH}
+export GH_PROJECT=${GITHUB_REPOSITORY}
+export GH_SHA=${GITHUB_SHA}
+export GH_PR_NUMBER=${GITHUB_PR_NUMBER}
+
+# adding attributes to XML to correlate the test run with the CI.
+xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
+  --type attr -n "github_event_type" -v "$GH_EVENT" ${NEW_RELIC_TEST_OUTPUT_PATH}
+
+xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
+  --type attr -n "github_trigger_branch" -v "$GH_BRANCH" ${NEW_RELIC_TEST_OUTPUT_PATH}
+
+xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
+  --type attr -n "github_repository" -v "$GH_PROJECT" ${NEW_RELIC_TEST_OUTPUT_PATH}
+
+xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
+  --type attr -n "github_commit" -v "$GH_SHA" ${NEW_RELIC_TEST_OUTPUT_PATH}
+
+xmlstarlet ed -O --inplace --insert "/testsuites/testsuite/testcase" \
+  --type attr -n "github_pr_number" -v "$GH_PR_NUMBER" ${NEW_RELIC_TEST_OUTPUT_PATH}
+
+# use newrelic cli to send the junit report to newrelic
+result=$(newrelic reporting junit \
+  --accountId "${NEW_RELIC_ACCOUNT_ID}" \
+  --path "${NEW_RELIC_TEST_OUTPUT_PATH}" \
+  2>&1)
+
+exitStatus=$?
+
+if [ $exitStatus -ne 0 ]; then
+  echo "::error:: $result"
+fi
+
+exit $exitStatus


### PR DESCRIPTION
### Context

We have gathered concerns around test flakiness and elevated test execution time on multiple occasions. Rather than waiting for anecdotal evidences of test efficacy, we should have a proactive approach of getting alerted if our tests are downgrading the quality of our CI pipelines.

We did some experiments with third party products like ForeSight that seamlessly integrate with our GitHub Actions to five some insights on how our tests are running. However, with ForeSight ceasing operations, we could try to build in-house utilities to increase the visibility into our test execution in our CI.

### What this does 

This action can send the JUNIT XML results from your CI to NewRelic for you to have observability of your Test Executions in the CI. Since JUNIT test reporting is more or less a standard across all testing frameworks, it can be used with any framework to draw insights from the test execution in our CI.

With this data in New Relic, we can create alerts on abnormalities like High CI failure rate, test flakiness and test fragility to identify the weak spots in our test suites and CI.

### What do you need to integrate?

Just the NR ingestion key and account id are required to get going. Other identifiers like PR id, project name, etc are pulled from the GH actions itself. You can checkout the action README for more information
