### PR TITLE
Improve Node.js setup cache key

### DIFF
--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -32,7 +32,7 @@ runs:
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
Use `package.json` and `npm-shrinkwrap` as NPM cache key inputs