### PR TITLE
Allows configuring the release branch

### DIFF
--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'The Node.js version to use in the Action'
     required: false
     default: 'lts/*'
+  release-branch:
+    description: 'The branch to use for the release.'
+    required: false
 
 runs:
   using: "composite"
@@ -42,6 +45,6 @@ runs:
       shell: bash
       # Must use `github.action_path` since the script is located in a separate checkout than the calling repo.
       # @see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
-      run: ${{ github.action_path }}/bin/publish.sh -t ${{ inputs.npm-version-type }}
+      run: ${{ github.action_path }}/bin/publish.sh -t ${{ inputs.npm-version-type }} -b ${{ inputs.release-branch }}
       env:
         NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -8,6 +8,7 @@ set -o pipefail  # error if piped command fails
 # Default variables
 NPM_VERSION_TYPE=
 MAIN_BRANCH="$(LC_ALL=C git remote show origin | awk '/HEAD branch/ {print $NF}')"
+RELEASE_BRANCH=$MAIN_BRANCH
 
 echo_title() {
 	echo ""
@@ -19,6 +20,9 @@ do
 	case $option in
 		# npm major/minor/patch
 		t) NPM_VERSION_TYPE=$OPTARG ;;
+
+		# release branch
+		b) [ -n "$OPTARG" ] && RELEASE_BRANCH=$OPTARG ;;
 
 		\?) echo "Error: Invalid param / option specified"
 			exit 199 ;;
@@ -52,8 +56,8 @@ echo "✅ Logged in as $NPM_USER and ready to publish"
 # Validate current branch
 echo_title "Checking branch"
 # TODO: add support for release/** branch via [ ! "$LOCAL_BRANCH" == "$RELEASE_BRANCH_PATTERN" ] -- will need to add version checking support as well
-if [ "$LOCAL_BRANCH" != "$MAIN_BRANCH" ]; then
-	echo "❌ You can only publish from the '$MAIN_BRANCH' branch. Please switch branches and try again."
+if [ "$LOCAL_BRANCH" != "$RELEASE_BRANCH" ]; then
+	echo "❌ You can only publish from the '$RELEASE_BRANCH' branch. Please switch branches and try again."
 	exit 202
 fi
 echo "✅ On a valid release branch ($LOCAL_BRANCH)"
@@ -118,7 +122,7 @@ echo "✅ Successfully published new '$NPM_VERSION_TYPE' release for $LOCAL_NAME
 
 # Version bump to dev
 # Not needed for release branches so we only do on the main branch
-if [ "$LOCAL_BRANCH" == "$MAIN_BRANCH" ]; then
+if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ]; then
 	echo_title "npm version (to next dev)"
 
 	NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"


### PR DESCRIPTION
On the VIP CLI, the default branch is `develop` but we often want to release from `trunk`. This adds the possibility to configure the publish action so that we can pass what the release branch is:

```yml
jobs:
  publish:
    name: Publish to npm
    runs-on: ubuntu-latest
    steps:
      - uses: Automattic/vip-actions/npm-publish@v0.1.1
        with:
          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
          npm-version-type: ${{ inputs.npm-version-type }}
          release-branch: trunk
```