### PR TITLE
feat: introduce npm-publish-prerelease action

### DIFF
--- a/npm-publish-prerelease/README.md
+++ b/npm-publish-prerelease/README.md
@@ -7,8 +7,8 @@ This action will publish a prerelease version of the package to npm with the spe
 * `NPM_TOKEN`: (required) the npm token used to publish the package.
 * `GH_TOKEN`: (optional) the GitHub access token to use (default: `${{ github.token }}`).
 * `node-version`: (optional) the Node.js version to use for the Action.
-* `npm-tag`: (optional) NPM [distribution tag](https://docs.npmjs.com/adding-dist-tags-to-packages) (default: `next`)
-* `provenance`: (optional) set to `true` to generate provenance statement for the published package. Requires the `id-token: write` permission.
+* `NPM_TAG`: (optional) NPM [distribution tag](https://docs.npmjs.com/adding-dist-tags-to-packages) (default: `next`).
+* `PROVENANCE`: (optional) set to `true` to generate provenance statement for the published package. Requires the `id-token: write` permission.
 
 ## Using the action
 
@@ -52,8 +52,8 @@ jobs:
       - uses: Automattic/vip-actions/npm-publish-prerelease@master
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          npm-tag: ${{ inputs.npm-tag }}
-          provenance: ${{ inputs.provenance }}
+          NPM_TAG: ${{ inputs.npm-tag }}
+          PROVENANCE: ${{ inputs.provenance }}
 ```
 
 4. Ensure that tokens can be used to publish the relevant npm package and that the particular token used has permissions to do so.

--- a/npm-publish-prerelease/README.md
+++ b/npm-publish-prerelease/README.md
@@ -1,0 +1,59 @@
+# Publish prerelease to npm
+
+This action will publish a prerelease version of the package to npm with the specified distribution tag.
+
+## Inputs
+
+* `NPM_TOKEN`: (required) the npm token used to publish the package.
+* `GH_TOKEN`: (optional) the GitHub access token to use (default: `${{ github.token }}`).
+* `node-version`: (optional) the Node.js version to use for the Action.
+* `npm-tag`: (optional) NPM [distribution tag](https://docs.npmjs.com/adding-dist-tags-to-packages) (default: `next`)
+* `provenance`: (optional) set to `true` to generate provenance statement for the published package. Requires the `id-token: write` permission.
+
+## Using the action
+
+1. Add a GitHub Actions secret (Settings > Secrets > Actions) called `NPM_TOKEN` which is an automation token for the npmjs.com user you'll use to publish to npm.
+2. If you require any form of clean + build steps to be run prior to publishing, do so via an npm script called `prepare`. The publish script triggers `npm run prepare --if-present` as part of the install and test step. Here's an example snippet from `package.json` (note: it assumes you have `rimraf` installed as a `devDep`):
+
+```
+"scripts": {
+  ...
+  "prepare": "npm run clean && npm run build",
+  "clean": "rimraf dist",
+  "build": "babel src -o dist",
+  ...
+},
+```
+
+3. Add the following to a `npm-publish-prerelease.yml` file in `.github/workflows` in the main branch of the GitHub repository you want to publish to npm:
+
+```yaml
+name: 'Publish prerelease to npm'
+on:
+  workflow_dispatch:
+    inputs:
+      npm-tag:
+        description: 'Package distribution tag'
+        required: true
+        default: 'next'
+      provenance:
+        description: 'Generate package provenance statement'
+        required: true
+        type: boolean
+        default: true
+jobs:
+  publish:
+    name: Publish prerelease to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: Automattic/vip-actions/npm-publish-prerelease@master
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm-tag: ${{ inputs.npm-tag }}
+          provenance: ${{ inputs.provenance }}
+```
+
+4. Ensure that tokens can be used to publish the relevant npm package and that the particular token used has permissions to do so.

--- a/npm-publish-prerelease/action.yml
+++ b/npm-publish-prerelease/action.yml
@@ -1,0 +1,50 @@
+---
+name: Publish a prerelease version of the package to npm
+description: This action automates various aspects of publishing a package to the npm registry including running tests, versioning, and tagging.
+inputs:
+  NPM_TOKEN:
+    description: 'The npm token used to publish the package.'
+    required: true
+  GH_TOKEN:
+    description: 'The GitHub access token used to create labels and pull requests.'
+    default: ${{ github.token }}
+  node-version:
+    description: 'The Node.js version to use in the Action'
+    required: false
+    default: 'lts/*'
+  provenance:
+    description: 'Generate provenance statement for the published package.'
+    default: 'false'
+  npm-tag:
+    description: 'The npm tag to use when publishing the package.'
+    default: 'next'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: https://registry.npmjs.org/
+        cache: npm
+
+    - name: git config
+      shell: bash
+      run: |
+        git config --global user.name "WordPress VIP Bot"
+        git config --global user.email "<22917138+wpcomvip-bot@users.noreply.github.com>"
+
+    - name: Validate & Publish
+      shell: bash
+      # Must use `github.action_path` since the script is located in a separate checkout than the calling repo.
+      # @see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
+      run: ${{ github.action_path }}/bin/publish.sh
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
+        GH_TOKEN: ${{ inputs.GH_TOKEN }}
+        PROVENANCE: ${{ inputs.provenance }}
+        NPM_TAG: ${{ inputs.npm-tag }}

--- a/npm-publish-prerelease/action.yml
+++ b/npm-publish-prerelease/action.yml
@@ -12,10 +12,10 @@ inputs:
     description: 'The Node.js version to use in the Action'
     required: false
     default: 'lts/*'
-  provenance:
+  PROVENANCE:
     description: 'Generate provenance statement for the published package.'
     default: 'false'
-  npm-tag:
+  NPM_TAG:
     description: 'The npm tag to use when publishing the package.'
     default: 'next'
 
@@ -46,5 +46,5 @@ runs:
       env:
         NODE_AUTH_TOKEN: ${{ inputs.NPM_TOKEN }}
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
-        PROVENANCE: ${{ inputs.provenance }}
-        NPM_TAG: ${{ inputs.npm-tag }}
+        PROVENANCE: ${{ inputs.PROVENANCE }}
+        NPM_TAG: ${{ inputs.NPM_TAG }}

--- a/npm-publish-prerelease/bin/publish.sh
+++ b/npm-publish-prerelease/bin/publish.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+set -eu
+
+# Set inputs
+: "${NPM_TAG:=next}"
+: "${PROVENANCE:=false}"
+
+echo_title() {
+	echo ""
+	echo "== $1 =="
+}
+
+# Fetch some basic package information
+echo_title "Fetching local package info"
+LOCAL_NAME=$(node -p "require('./package.json').name")
+LOCAL_VERSION=$(node -p "require('./package.json').version")
+LOCAL_BRANCH=$(git branch --show-current)
+echo "✅ Found ${LOCAL_NAME} ${LOCAL_VERSION} on branch ${LOCAL_BRANCH}"
+
+# Validate npm is logged in and ready
+echo_title "Checking npm auth"
+if ! NPM_USER=$(npm whoami); then
+	echo "❌ npm cli is not authenticated. Please make sure you're logged in or NPM_TOKEN is set."
+	exit 202
+fi
+echo "✅ Logged in as ${NPM_USER} and ready to publish"
+
+# Validate no uncommitted changes.
+# Shouldn't happen in CI but protects against local runs.
+echo_title "Checking for local changes"
+if ! git diff-index --quiet HEAD --; then
+	echo "❌ Working directory has uncommitted changes; please clean up before proceeding."
+	exit 204
+fi
+echo "✅ No local changes found"
+
+# Install
+echo_title "npm ci + test"
+
+# Install dependencies but skip pre/post scripts since our auth token is in place
+npm ci --ignore-scripts
+
+# Run scripts + tests without auth token to prevent malicious access
+NODE_AUTH_TOKEN='' npm rebuild
+NODE_AUTH_TOKEN='' npm run prepare --if-present
+NODE_AUTH_TOKEN='' npm test
+echo "✅ npm install + npm test look good"
+
+# Confirm y/n (if running locally)
+if [ -t 0 ]; then
+	echo_title "Confirm release"
+	printf "Are you sure you want to publish a new release? (y/n)"
+	read -r yn
+	case $yn in
+		[Yy]*) 
+		;;
+
+		*)
+			echo "❌ Aborting release"
+			exit 205
+		;;
+	esac
+fi
+
+# Publish with Dry Run
+echo_title "npm publish (dry-run)"
+npm publish --access public --tag "${NPM_TAG}" --dry-run
+echo "✅ Dry run looks good"
+
+# Publish on GitHub and tag
+echo_title "Publishing a new release on GitHub and tagging"
+gh release create "${LOCAL_VERSION}" --generate-notes --prerelease --target "${LOCAL_BRANCH}"
+echo "✅ Released version ${LOCAL_VERSION} on GitHub and tagged"
+
+# Publish to NPM
+echo_title "npm publish"
+OPTIONS="--access public --tag ${NPM_TAG}"
+if [ "${PROVENANCE}" = "true" ] && [ "${CI:-}" = "true" ] && [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+	OPTIONS="${OPTIONS} --provenance"
+fi
+
+# shellcheck disable=SC2086 # We want to pass the options as a string
+npm publish ${OPTIONS}
+echo "✅ Successfully published new release for ${LOCAL_NAME} as ${LOCAL_VERSION}"


### PR DESCRIPTION
This PR introduces the `npm-publish-prerelease` action.

It is designed to publish the package's prerelease version (e.g., `package@next`) to NPM. The goal is to publish packages from a CI pipeline; this, for example, enables us to generate and publish provenance attestations for all published versions of the packages.

This action is meant to run from a `workflow_dispatch` pipeline.

The developer is responsible for setting the correct package version in `package.json`.
