### PR TITLE
feat: introduce expose-github-runtime action

### DIFF
--- a/expose-github-runtime/README.md
+++ b/expose-github-runtime/README.md
@@ -1,0 +1,24 @@
+# Expose GitHub Runtime
+
+This action exposes GitHub runtime to the workflow.
+
+This is required if the workflow runs a script that needs to access the GitHub API (for example, upload an artifact or work with the cache). The script will need access to such variables as `ACTIONS_RUNTIME_TOKEN` or `ACTIONS_RUNTIME_URL`; they are normally exposed to the actions, not to the scripts.
+
+#### Example
+
+```yaml
+name: My Workflow
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  expose-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Automattic/vip-actions/expose-github-runtime@trunk
+      - run: env | grep ACTIONS_
+      # Say, you need to build a Docker image and reuse action cache; the 'type=gha' needs the GitHub runtime
+      - run: docker buildx build -t "ghcr.io/repo/image:latest" --cache-from type=gha --cache-to type=gha,mode=max .
+```

--- a/expose-github-runtime/action.yml
+++ b/expose-github-runtime/action.yml
@@ -1,0 +1,15 @@
+name: Expose GitHub runtime
+description: This action exposes the GitHub runtime to the workflow
+
+runs:
+  using: composite
+  steps:
+    - name: Expose runtime
+      uses: actions/github-script@v7
+      with:
+        script: |
+          Object.keys(process.env).forEach((key) => {
+            if (key.startsWith('ACTIONS_')) {
+              core.exportVariable(key, process.env[key]);
+            }
+          });


### PR DESCRIPTION
This PR adds an action to expose the GitHub runtime to the workflow. We need this action in VIP CLI Express to be able to publish Node.js binaries for `nexe` as artifacts.

It can also be helpful for VIP Codespaces to simplify the workflows to build base images.