### PR TITLE
feat: follow conventional commits spec to create commit messages

### DIFF
--- a/npm-prepare-release/README.md
+++ b/npm-prepare-release/README.md
@@ -4,7 +4,7 @@ This action prepares a repository for publishing to npm and is designed to work 
 
 The `npm-prepare-release` action should be called first using manual dispatch. Once added to a repository and run, it will increase the npm package's version number in accordance with input from the caller (requested when dispatched). This is normally expected to be done from the main branch of the repository. It will then commit this change to the GitHub repository, and create a new pull request that is assigned to the caller of the action. The caller should review and merge the pull request once they feel their changes are ready.
 
-Note that a custom release branch can be used instead of the main branch. This will have to be configured using a custom input value (see below). 
+Note that a custom release branch can be used instead of the main branch. This will have to be configured using a custom input value (see below).
 
 Usage of the two actions is compatible with [GitHub Branch Protection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and requires only the standard GitHub Actions access token provided (with read-write permission). No GitHub bot account is needed.
 
@@ -13,7 +13,8 @@ Usage of the two actions is compatible with [GitHub Branch Protection](https://d
 * `GH_TOKEN`: (required) the GitHub access token to use. It is recommended to use the standard GitHub Actions access token (used in example).
 * `npm-version-type`: (required) the npm version type (`major`|`minor`|`patch`) being published.
 * `node-version`: (optional) the Node.js version to use for the action.
-* `release-branch`: (optional) custom branch to use for releasing the package instead of the main branch. 
+* `release-branch`: (optional) custom branch to use for releasing the package instead of the main branch.
+* `conventional-commits`: (optional) set to `true` to generate commit messages that follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
 
 ## Using the action
 
@@ -40,7 +41,7 @@ jobs:
   prepare:
     name: Prepare a new npm release
     runs-on: ubuntu-latest
-    steps:    
+    steps:
       - name: Check out the source code
         uses: actions/checkout@v3
 

--- a/npm-prepare-release/action.yml
+++ b/npm-prepare-release/action.yml
@@ -22,6 +22,9 @@ inputs:
   release-branch:
     description: 'The branch to use for the release.'
     required: false
+  conventional-commits:
+    description: 'Follow the Conventional Commits specification when generating commit message.'
+    default: 'false'
 
 runs:
   using: "composite"
@@ -49,3 +52,4 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         PR_ASSIGNEE: ${{ github.actor }}
+        CONVENTIONAL_COMMITS: ${{ inputs.conventional-commits }}

--- a/npm-prepare-release/bin/prepare-release.sh
+++ b/npm-prepare-release/bin/prepare-release.sh
@@ -20,13 +20,13 @@ do
 	case $option in
 		# npm major/minor/patch
 		t) NPM_VERSION_TYPE=$OPTARG ;;
-  
+
 		# release branch
 		b) [ -n "$OPTARG" ] && RELEASE_BRANCH=$OPTARG ;;
-  
+
 		\?) echo "Error: Invalid param / option specified"
 			exit 199 ;;
-   esac
+	esac
 done
 
 # Validate release type value
@@ -81,7 +81,7 @@ echo "✅ Checked out git branch ($NEW_BRANCH)"
 
 # git commit
 echo_title "git commit"
-git commit -a -m "Commiting new version of package"
+git commit -a -m "chore: bump package version to ${NEW_VERSION}"
 echo "✅ Commit new version of package to git branch"
 
 # git push

--- a/npm-prepare-release/bin/prepare-release.sh
+++ b/npm-prepare-release/bin/prepare-release.sh
@@ -81,7 +81,11 @@ echo "✅ Checked out git branch ($NEW_BRANCH)"
 
 # git commit
 echo_title "git commit"
-git commit -a -m "chore: bump package version to ${NEW_VERSION}"
+if [ "${CONVENTIONAL_COMMITS:-}" = 'true' ]; then
+	git commit -a -m "chore: bump package version to ${NEW_VERSION}"
+else
+	git commit -a -m "Bump package version to ${NEW_VERSION}"
+fi
 echo "✅ Commit new version of package to git branch"
 
 # git push

--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -10,6 +10,7 @@ The `npm-prepare-release` action is meant to be called first and will create a p
 * `GH_TOKEN`: (required) the GitHub access token to use. It is recommended to use the standard GitHub Actions access token (used in example).
 * `node-version`: (optional) the Node.js version to use for the Action.
 * `PROVENANCE`: (optional) set to `true` to generate provenance statement for the published package. Requires the `id-token: write` permission.
+* `CONVENTIONAL_COMMITS`: (optional) set to `true` to generate commit messages that follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
 
 ## Using the action
 

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -16,6 +16,9 @@ inputs:
   PROVENANCE:
     description: 'Generate provenance statement for the published package.'
     default: 'false'
+  CONVENTIONAL_COMMITS:
+    description: 'Follow the Conventional Commits specification when generating commit message.'
+    default: 'false'
 
 runs:
   using: "composite"
@@ -47,3 +50,4 @@ runs:
         PR_HEAD_REF: ${{ github.head_ref }}
         PR_ASSIGNEE: ${{ github.actor }}
         PROVENANCE: ${{ inputs.PROVENANCE }}
+        CONVENTIONAL_COMMITS: ${{ inputs.CONVENTIONAL_COMMITS }}

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -154,7 +154,11 @@ if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ]; then
 	echo "✅ Check out git branch ($NEW_BRANCH)"
 
 	git add -u
-	git commit -m "chore: bump to next $NEXT_LOCAL_DEV_VERSION_TYPE: ($NEXT_LOCAL_DEV_VERSION)"
+	if [ "${CONVENTIONAL_COMMITS:-}" = 'true' ]; then
+		git commit -m "chore: bump to next $NEXT_LOCAL_DEV_VERSION_TYPE: ($NEXT_LOCAL_DEV_VERSION)"
+	else
+		git commit -m "Bump to next $NEXT_LOCAL_DEV_VERSION_TYPE: ($NEXT_LOCAL_DEV_VERSION)"
+	fi
 	echo "✅ Commit to GitHub repository ($NEW_BRANCH)"
 	git push --follow-tags
 	echo "✅ Pushed commit to GitHub repository"

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -154,7 +154,7 @@ if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ]; then
 	echo "✅ Check out git branch ($NEW_BRANCH)"
 
 	git add -u
-	git commit -m "Bump to next $NEXT_LOCAL_DEV_VERSION_TYPE: ($NEXT_LOCAL_DEV_VERSION)"
+	git commit -m "chore: bump to next $NEXT_LOCAL_DEV_VERSION_TYPE: ($NEXT_LOCAL_DEV_VERSION)"
 	echo "✅ Commit to GitHub repository ($NEW_BRANCH)"
 	git push --follow-tags
 	echo "✅ Pushed commit to GitHub repository"


### PR DESCRIPTION
Use `chore:` prefix in commit messages in order not to break workflows that use `nlm` (for example, `Automattic/vip-search-replace`).

Ref: https://github.com/Automattic/vip-search-replace/actions/runs/7180201794/job/19551947792?pr=66