### PR TITLE
feat(npm-publish): add `SKIP_BUMP_TO_DEV` option to support projects with `nlm`

### DIFF
--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -11,6 +11,7 @@ The `npm-prepare-release` action is meant to be called first and will create a p
 * `node-version`: (optional) the Node.js version to use for the Action.
 * `PROVENANCE`: (optional) set to `true` to generate provenance statement for the published package. Requires the `id-token: write` permission.
 * `CONVENTIONAL_COMMITS`: (optional) set to `true` to generate commit messages that follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
+* `SKIP_BUMP_TO_DEV`: (optional) set to `true` to skip bumping to dev version after publishing the release. Might be useful for projects using `nlm`.
 
 ## Using the action
 

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -19,6 +19,9 @@ inputs:
   CONVENTIONAL_COMMITS:
     description: 'Follow the Conventional Commits specification when generating commit message.'
     default: 'false'
+  SKIP_BUMP_TO_DEV:
+    description: 'Skip bumping to dev version after publishing the release.'
+    default: 'false'
 
 runs:
   using: "composite"
@@ -51,3 +54,4 @@ runs:
         PR_ASSIGNEE: ${{ github.actor }}
         PROVENANCE: ${{ inputs.PROVENANCE }}
         CONVENTIONAL_COMMITS: ${{ inputs.CONVENTIONAL_COMMITS }}
+        SKIP_BUMP_TO_DEV: ${{ inputs.SKIP_BUMP_TO_DEV }}

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -21,7 +21,7 @@ set -o errexit # exit on error
 
 if [ "$PR_FILES_CHANGED" != "0" ] ; then
 	echo "❌ Unexpected files changed in PR ($PR_FILES_CHANGED)"
- 	exit 200
+	exit 200
 else
 	echo "✅ Determined only .json files are changed in PR"
 fi
@@ -129,7 +129,7 @@ npm publish ${OPTIONS}
 echo "✅ Successfully published new '$NPM_VERSION_TYPE' release for $LOCAL_NAME as $LOCAL_VERSION"
 
 # Version bump to dev - create a branch and a PR, then merge
-if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ]; then
+if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ] && [ "${SKIP_BUMP_TO_DEV:-}" != 'true' ]; then
 	echo_title "npm version (to next dev)"
 
 	NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"


### PR DESCRIPTION
This affects projects like `@automattic/vip-search-replace`.

After publishing a new release, we create another PR to bump the current version of the package to a `-dev` version. However, this breaks `nlm`: it expects to find a tag matching the new version, and that tag does not exist.

Ref: https://github.com/Automattic/vip-search-replace/actions/runs/7380197377/job/20077316527?pr=74#step:7:7
