### PR TITLE
feat(npm-publish): add `TAG_PREFIX`

### DIFF
--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -12,6 +12,7 @@ The `npm-prepare-release` action is meant to be called first and will create a p
 * `PROVENANCE`: (optional) set to `true` to generate provenance statement for the published package. Requires the `id-token: write` permission.
 * `CONVENTIONAL_COMMITS`: (optional) set to `true` to generate commit messages that follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
 * `SKIP_BUMP_TO_DEV`: (optional) set to `true` to skip bumping to dev version after publishing the release. Might be useful for projects using `nlm`.
+* `TAG_PREFIX`: (optional) set tag prefix (for example, `v`). Might be useful for projects using `nlm`.
 
 ## Using the action
 

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -22,6 +22,9 @@ inputs:
   SKIP_BUMP_TO_DEV:
     description: 'Skip bumping to dev version after publishing the release.'
     default: 'false'
+  TAG_PREFIX:
+    description: 'Prefix for the git tag.'
+    default: ''
 
 runs:
   using: "composite"
@@ -55,3 +58,4 @@ runs:
         PROVENANCE: ${{ inputs.PROVENANCE }}
         CONVENTIONAL_COMMITS: ${{ inputs.CONVENTIONAL_COMMITS }}
         SKIP_BUMP_TO_DEV: ${{ inputs.SKIP_BUMP_TO_DEV }}
+        TAG_PREFIX: ${{ inputs.TAG_PREFIX }}

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -114,7 +114,7 @@ echo "✅ Dry run looks good"
 
 # Publish on GitHub and tag
 echo_title "Publishing a new release on GitHub and tagging"
-gh release create "$LOCAL_VERSION" --generate-notes --target "$RELEASE_BRANCH"
+gh release create "${TAG_PREFIX:-}${LOCAL_VERSION}" --generate-notes --target "${RELEASE_BRANCH}"
 echo "✅ Released version $LOCAL_VERSION on GitHub and tagged"
 
 # Publish to NPM


### PR DESCRIPTION
Adds `TAG_PREFIX` parameter to prefix git tags optionally. This can be useful for projects using `nlm`, as it expects all tags to have the `v` prefix.
