### PR TITLE
npm-publish: Always prepatch when bumping dev versions

### DIFF
--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -133,12 +133,6 @@ if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ] && [ "${SKIP_BUMP_TO_DEV:-}" != 'tru
 	echo_title "npm version (to next dev)"
 
 	NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
-	if [ "$NPM_VERSION_TYPE" == "major" ]; then
-		NEXT_LOCAL_DEV_VERSION_TYPE="preminor"
-	elif [ "$NPM_VERSION_TYPE" == "minor" ]; then
-		NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
-	fi
-
 	NEXT_LOCAL_DEV_VERSION=$( npm version --no-git-tag-version --preid "dev" "$NEXT_LOCAL_DEV_VERSION_TYPE" )
 	echo "✅ Determined next local dev version: $NEXT_LOCAL_DEV_VERSION"
 


### PR DESCRIPTION
Fixes #62 

Currently, the `npm-publish` script bumps a dev version as a `preminor` when the last released version was a `major`. I did some investigation in #62 that makes me think that we should always `prepatch` for dev releases, no matter what version came before.

The code removes the if statement and makes `prepatch` as the default version for dev releases.