### PR TITLE
Updated custom deployment from "slug" to "alias"

### DIFF
--- a/custom-deployment/README.md
+++ b/custom-deployment/README.md
@@ -1,13 +1,13 @@
 # Custom Deployments. 
 
 This action allows you to use the release feature from GitHub to create a new deployable artifact from any GitHub Repo and deploy it to any of your WordPress VIP environments. 
-To run this you need to ensure that the `WPVIP_DEPLOY_TOKEN` secret and `ENVIRONMENT_SLUG` variable are set correctly. 
+To run this you need to ensure that the `WPVIP_DEPLOY_TOKEN` secret and `ENVIRONMENT_TYPE` variable are set correctly. 
 Note: Custom Deployments is currently in close beta and not yet available for the broader audience.  
 
 ## Inputs
 
 * `WPVIP_DEPLOY_TOKEN`: (required) The deployment token you can obtain on the "repository" page for your applications.
-* `ENVIRONMENT_SLUG`: (required) The environment slug used in the CLI to specify which application environment you're referencing.
+* `ENVIRONMENT_TYPE`: (required) The environment type used in the CLI to specify which application environment you're referencing.
 * `RELEASE_NAME`: (required) The name of the release, typically sourced from the GitHub event data.
 
 ## Example
@@ -27,7 +27,7 @@ jobs:
       - uses: Automattic/vip-actions/custom-deployment@trunk
         with:
           WPVIP_DEPLOY_TOKEN: ${{ secrets.WPVIP_DEPLOY_TOKEN }}
-          ENVIRONMENT_SLUG: ${{ vars.ENVIRONMENT_SLUG }}
+          ENVIRONMENT_TYPE: ${{ vars.ENVIRONMENT_TYPE }}
           RELEASE_NAME: ${{ github.event.release.name }}
 
 ```

--- a/custom-deployment/README.md
+++ b/custom-deployment/README.md
@@ -1,13 +1,13 @@
 # Custom Deployments. 
 
 This action allows you to use the release feature from GitHub to create a new deployable artifact from any GitHub Repo and deploy it to any of your WordPress VIP environments. 
-To run this you need to ensure that the `WPVIP_DEPLOY_TOKEN` secret and `ENVIRONMENT_TYPE` variable are set correctly. 
+To run this you need to ensure that the `WPVIP_DEPLOY_TOKEN` secret and `ENVIRONMENT_ALIAS` variable are set correctly. 
 Note: Custom Deployments is currently in close beta and not yet available for the broader audience.  
 
 ## Inputs
 
 * `WPVIP_DEPLOY_TOKEN`: (required) The deployment token you can obtain on the "repository" page for your applications.
-* `ENVIRONMENT_TYPE`: (required) The environment type used in the CLI to specify which application environment you're referencing.
+* `ENVIRONMENT_ALIAS`: (required) The environment alias (e.g. @appid.environment) used in the CLI to specify which application environment you're referencing.
 * `RELEASE_NAME`: (required) The name of the release, typically sourced from the GitHub event data.
 
 ## Example
@@ -27,7 +27,7 @@ jobs:
       - uses: Automattic/vip-actions/custom-deployment@trunk
         with:
           WPVIP_DEPLOY_TOKEN: ${{ secrets.WPVIP_DEPLOY_TOKEN }}
-          ENVIRONMENT_TYPE: ${{ vars.ENVIRONMENT_TYPE }}
+          ENVIRONMENT_ALIAS: ${{ vars.ENVIRONMENT_ALIAS }}
           RELEASE_NAME: ${{ github.event.release.name }}
 
 ```

--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -4,8 +4,8 @@ inputs:
   WPVIP_DEPLOY_TOKEN:
     description: 'The deploy token for WPVIP'
     required: true
-  ENVIRONMENT_SLUG:
-    description: 'The environment slug for deployment'
+  ENVIRONMENT_TYPE:
+    description: 'The environment type for deployment'
     required: true
   RELEASE_NAME:
     description: 'The name of the release'
@@ -23,8 +23,8 @@ runs:
           echo "Save the deploy token as WPVIP_DEPLOY_TOKEN."
           exit 1
         fi
-        if [ -z "${{ inputs.ENVIRONMENT_SLUG }}" ]; then
-          echo "ENVIRONMENT_SLUG is not set."
+        if [ -z "${{ inputs.ENVIRONMENT_TYPE }}" ]; then
+          echo "ENVIRONMENT_TYPE is not set."
           exit 1
         fi
       shell: bash
@@ -53,7 +53,7 @@ runs:
 
     - name: Deploy via VIP-CLI
       run: |
-        vip app deploy ${{ inputs.ENVIRONMENT_SLUG }} ./repo.zip --message "${{ inputs.RELEASE_NAME }}" --force
+        vip app deploy ${{ inputs.ENVIRONMENT_TYPE }} ./repo.zip --message "${{ inputs.RELEASE_NAME }}" --force
       shell: bash
       env:
         WPVIP_DEPLOY_TOKEN: ${{ inputs.WPVIP_DEPLOY_TOKEN }}

--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -67,4 +67,3 @@ runs:
       shell: bash
       env:
         WPVIP_DEPLOY_TOKEN: ${{ inputs.WPVIP_DEPLOY_TOKEN }}
-

--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -24,6 +24,7 @@ runs:
           echo "Save the deploy token as WPVIP_DEPLOY_TOKEN."
           exit 1
         fi
+        
         if [ -z "${{ inputs.ENVIRONMENT_TYPE }}" ] && [ -z "${{ inputs.ENVIRONMENT_SLUG }}" ]; then
           echo "Either ENVIRONMENT_TYPE or ENVIRONMENT_SLUG must be set."
           exit 1

--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -4,8 +4,8 @@ inputs:
   WPVIP_DEPLOY_TOKEN:
     description: 'The deploy token for WPVIP'
     required: true
-  ENVIRONMENT_TYPE:
-    description: 'The environment type for deployment'
+  ENVIRONMENT_ALIAS:
+    description: 'The environment alias for deployment. Format should be "@APPID.ENVIRONMENT"'
   ENVIRONMENT_SLUG:
     description: 'Backwards compatibility for pre-release versions'
   RELEASE_NAME:
@@ -25,13 +25,13 @@ runs:
           exit 1
         fi
         
-        if [ -z "${{ inputs.ENVIRONMENT_TYPE }}" ] && [ -z "${{ inputs.ENVIRONMENT_SLUG }}" ]; then
-          echo "Either ENVIRONMENT_TYPE or ENVIRONMENT_SLUG must be set."
+        if [ -z "${{ inputs.ENVIRONMENT_ALIAS }}" ] && [ -z "${{ inputs.ENVIRONMENT_SLUG }}" ]; then
+          echo "Either ENVIRONMENT_ALIAS or ENVIRONMENT_SLUG must be set."
           exit 1
         fi
 
-        if [ -n "${{ inputs.ENVIRONMENT_TYPE }}" ]; then
-          DEPLOY_ENVIRONMENT="${{ inputs.ENVIRONMENT_TYPE }}"
+        if [ -n "${{ inputs.ENVIRONMENT_ALIAS }}" ]; then
+          DEPLOY_ENVIRONMENT="${{ inputs.ENVIRONMENT_ALIAS }}"
         else
           DEPLOY_ENVIRONMENT="${{ inputs.ENVIRONMENT_SLUG }}"
         fi

--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   ENVIRONMENT_TYPE:
     description: 'The environment type for deployment'
-    required: true
+  ENVIRONMENT_SLUG:
+    description: 'Backwards compatibility for pre-release versions'
   RELEASE_NAME:
     description: 'The name of the release'
     required: true
@@ -23,10 +24,19 @@ runs:
           echo "Save the deploy token as WPVIP_DEPLOY_TOKEN."
           exit 1
         fi
-        if [ -z "${{ inputs.ENVIRONMENT_TYPE }}" ]; then
-          echo "ENVIRONMENT_TYPE is not set."
+        if [ -z "${{ inputs.ENVIRONMENT_TYPE }}" ] && [ -z "${{ inputs.ENVIRONMENT_SLUG }}" ]; then
+          echo "Either ENVIRONMENT_TYPE or ENVIRONMENT_SLUG must be set."
           exit 1
         fi
+
+        if [ -n "${{ inputs.ENVIRONMENT_TYPE }}" ]; then
+          DEPLOY_ENVIRONMENT="${{ inputs.ENVIRONMENT_TYPE }}"
+        else
+          DEPLOY_ENVIRONMENT="${{ inputs.ENVIRONMENT_SLUG }}"
+        fi
+        
+        echo "DEPLOY_ENVIRONMENT=${DEPLOY_ENVIRONMENT}" >> $GITHUB_ENV
+        
       shell: bash
 
 
@@ -53,7 +63,8 @@ runs:
 
     - name: Deploy via VIP-CLI
       run: |
-        vip app deploy ${{ inputs.ENVIRONMENT_TYPE }} ./repo.zip --message "${{ inputs.RELEASE_NAME }}" --force
+        vip app deploy ${{ env.DEPLOY_ENVIRONMENT }} ./repo.zip --message "${{ inputs.RELEASE_NAME }}" --force
       shell: bash
       env:
         WPVIP_DEPLOY_TOKEN: ${{ inputs.WPVIP_DEPLOY_TOKEN }}
+


### PR DESCRIPTION
We're moving from Environment slug to environment type to be consistent with the VIP guidelines. 
Note: This is a breaking change as we're renaming a variable. 