### PR TITLE
[Custom Deployments] Allows skipping the checkout step

### DIFF
--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -10,6 +10,10 @@ inputs:
   RELEASE_NAME:
     description: 'The name of the release'
     required: true
+  SKIP_CHECKOUT:
+    description: 'Skip the checkout step'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -29,9 +33,9 @@ runs:
         fi
       shell: bash
 
-
     - name: Checkout Repository
       uses: actions/checkout@v4
+      if: ${{ inputs.SKIP_CHECKOUT != 'true' }}
 
     - name: Setup Node
       uses: actions/setup-node@v4.0.2


### PR DESCRIPTION
In our workflow, we already do the checkout step in order to run composer before publishing. Now, when we run the custom deployment action we get:

```
Warning: Unable to clean or reset the repository. The repository will be recreated instead.
Deleting the contents of '/home/runner/work/vip-auth/vip-auth'
Error: File was unable to be removed Error: EACCES: permission denied, unlink '/home/runner/work/vip-auth/vip-auth/client-mu-plugins/vendor/autoload.php'
```

So we need to skip it in order to avoid conflicts.