### PR TITLE
Fix Node.js action setup hangs

### DIFF
--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -34,21 +34,13 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
-        cache: npm
 
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
-
-    - name: Cache Jest artifacts
-      uses: actions/cache@v4
-      id: cache-jest
-      with:
-        path: .cache/jest
-        key: ${{ runner.os }}-node-jest-${{ hashFiles('**/*.js', '**/*.ts', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -38,7 +38,7 @@ runs:
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ inputs.node-version || inputs.node-version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version || inputs.node-version-file }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -38,7 +38,7 @@ runs:
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -33,17 +33,12 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: npm
 
-    - name: Get Node.js major version
-      id: node-version
-      run: echo "version=$(node -v | cut -d. -f1 | tr -d 'v')" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version || hashFiles(inputs.node-version-file) }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -33,12 +33,17 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: npm
 
+    - name: Get Node.js major version
+      id: node-version
+      run: echo "version=$(node -v | cut -d. -f1 | tr -d 'v')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ inputs.node-version || inputs.node-version-file }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ steps.node-version.outputs.version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -38,7 +38,7 @@ runs:
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ inputs.version || inputs.node-version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version || inputs.node-version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -34,6 +34,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
+        cache: npm
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -38,7 +38,7 @@ runs:
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ inputs.node-version || hashFiles(inputs.node-version-file) }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -38,7 +38,7 @@ runs:
       id: cache-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ inputs.version || inputs.node-version }}-node-modules-cache-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Cache Jest artifacts
       uses: actions/cache@v4


### PR DESCRIPTION
See https://github.com/Automattic/remote-data-blocks/pull/107.

tl;dr: `action/cache` itself can be [surprising](https://github.com/actions/cache/issues/597) [at times](https://github.com/actions/cache/issues/795#issuecomment-1147921730); and I think, bottom line, it [does not easily cope](https://github.com/actions/cache/blob/main/src/saveImpl.ts#L116) well ~with fancy input/outputs from other steps when executing~.

~This tries to reduce usage in the `node_modules` caching step.~

Before:

<img width="258" alt="Screenshot 2024-09-25 at 5 04 46 PM" src="https://github.com/user-attachments/assets/e2d3b8e0-61b9-4f79-ba3d-709d695d02b3">


After:
<img width="255" alt="Screenshot 2024-09-25 at 5 04 54 PM" src="https://github.com/user-attachments/assets/757263a1-67c6-4c95-8705-989821553f7a">
