### PR TITLE
Add an ignore-scripts input to the Nodejs setup action

### DIFF
--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -15,6 +15,9 @@ inputs:
   ref:
     description: 'The branch, tag, or SHA to checkout'
     required: false
+  ignore-scripts:
+    description: 'Ignore scripts when installing dependencies'
+    required: false
 
 runs:
   using: composite
@@ -49,5 +52,5 @@ runs:
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: npm ci
+      run: npm ci ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
       shell: bash


### PR DESCRIPTION
This change provides a way to skip npm scripts when we run `npm ci`. 

An example: when your repo has a `postinstall` that does `composer install` but you don't need any of that for the CI job.