### PR TITLE
nodejs-setup: Add optional "working-directory" parameter

### DIFF
--- a/nodejs-setup/README.md
+++ b/nodejs-setup/README.md
@@ -51,4 +51,21 @@ jobs:
 
       - name: Run linter
         run: npm run lint
+
+  lint-other-app:
+    name: Other App: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup and install
+        uses: Automattic/vip-actions/nodejs-setup@trunk
+        with:
+          node-version-file: other-app/.nvmrc
+          working-directory: other-app
+
+      - name: Run linter 
+        working-directory: ./other-app
+        run: npm run lint
+
 ```

--- a/nodejs-setup/README.md
+++ b/nodejs-setup/README.md
@@ -10,6 +10,7 @@ One of `node-version` or `node-version-file` is required. Do not provide both.
 - `node-version-file`: Set to the file containing your preferred Node.js version (e.g., `.nvmrc` or `.node-version`).
 - `node-version`: Set to a valid semver referencing your preferred Node.js version (e.g., `18.13`).
 - `ref`: The branch, tag, or SHA to checkout (optional, defaults to commit that triggered the workflow).
+- `working-directory`: Effectively focuses checkout to this directory and uses as a working directory when running NPM install. Useful if you have a Node application inside a subdirectory and you only want that checked out and dependencies for it installed.  Do not prepend directory value with `./`. Optional parameter.
 
 ## Example
 

--- a/nodejs-setup/README.md
+++ b/nodejs-setup/README.md
@@ -10,7 +10,7 @@ One of `node-version` or `node-version-file` is required. Do not provide both.
 - `node-version-file`: Set to the file containing your preferred Node.js version (e.g., `.nvmrc` or `.node-version`).
 - `node-version`: Set to a valid semver referencing your preferred Node.js version (e.g., `18.13`).
 - `ref`: The branch, tag, or SHA to checkout (optional, defaults to commit that triggered the workflow).
-- `working-directory`: Effectively focuses checkout to this directory and uses as a working directory when running NPM install. Useful if you have a Node application inside a subdirectory and you only want that checked out and dependencies for it installed.  Do not prepend directory value with `./`. Optional parameter.
+- `working-directory`: Effectively limits checkout to this directory and uses as a working directory when running NPM install. Useful if you have a Node application inside a subdirectory and you only want that checked out and dependencies for it installed.  Do not prepend directory value with `./`. Optional parameter.
 
 ## Example
 

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -39,6 +39,7 @@ runs:
         sparse-checkout-cone-mode: false
 
     - name: LS
+      shell: bash
       run: ls -al ; ls -al ..
 
     - name: Set up Node.js environment using supplied Node.js version

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Ignore scripts when installing dependencies'
     required: false
   working-directory:
-    description: 'Working directory when running NPM install'
+    description: 'Effectively focuses checkout to this directory and uses as a working directory when running NPM install'
     required: false
     default: '.'
 

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -38,6 +38,9 @@ runs:
         sparse-checkout: ${{ inputs.sparse-checkout }}
         sparse-checkout-cone-mode: false
 
+    - name: LS
+      run: ls -al ; ls -al ..
+
     - name: Set up Node.js environment using supplied Node.js version
       id: setup-node
       uses: actions/setup-node@v4

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -49,6 +49,7 @@ runs:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
         cache: npm
+        cache-dependency-path: ${{ inputs.working-directory }}
 
     - name: LS2
       shell: bash
@@ -59,7 +60,6 @@ runs:
       id: cache-node-modules
       with:
         path: ${{ inputs.working-directory }}/node_modules
-        cache-dependency-path: ${{ inputs.working-directory }}
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: LS3

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -18,6 +18,10 @@ inputs:
   ignore-scripts:
     description: 'Ignore scripts when installing dependencies'
     required: false
+  sparse-checkout:
+    description: 'Do a sparse checkout on given patterns'
+    required: false
+    default: null
 
 runs:
   using: composite
@@ -27,6 +31,7 @@ runs:
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
+        sparse-checkout: ${{ inputs.sparse-checkout }}
 
     - name: Set up Node.js environment using supplied Node.js version
       id: setup-node

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -32,6 +32,7 @@ runs:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
         sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout-cone-mode: false
 
     - name: Set up Node.js environment using supplied Node.js version
       id: setup-node

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -25,7 +25,7 @@ inputs:
   working-directory:
     description: 'Working directory when running NPM install'
     required: false
-    default: './'
+    default: .
 
 runs:
   using: composite
@@ -53,7 +53,7 @@ runs:
       uses: actions/cache@v4
       id: cache-node-modules
       with:
-        path: node_modules
+        path: ${{ inputs.working-directory }}/node_modules
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -50,6 +50,10 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
         cache: npm
 
+    - name: LS2
+      shell: bash
+      run: ls -al ; ls -al .. ; ls -al api-wpvip-com
+
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache-node-modules
@@ -57,6 +61,10 @@ runs:
         path: ${{ inputs.working-directory }}/node_modules
         cache-dependency-path: ${{ inputs.working-directory }}
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+
+    - name: LS3
+      shell: bash
+      run: ls -al ; ls -al .. ; ls -al api-wpvip-com
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -34,10 +34,6 @@ runs:
         sparse-checkout: ${{ inputs.working-directory != '.' && inputs.working-directory || null }}
         sparse-checkout-cone-mode: false # Only used if sparse-checkout is non-null.
 
-    - name: LS
-      shell: bash
-      run: ls -al ; ls -al .. ; ls -al api-wpvip-com
-
     - name: Set up Node.js environment using supplied Node.js version
       id: setup-node
       uses: actions/setup-node@v4
@@ -47,20 +43,12 @@ runs:
         cache: npm
         cache-dependency-path: ${{ inputs.working-directory != '.' && inputs.working-directory || '' }}
 
-    - name: LS2
-      shell: bash
-      run: ls -al ; ls -al .. ; ls -al api-wpvip-com
-
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache-node-modules
       with:
         path: ${{ inputs.working-directory }}/node_modules
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
-
-    - name: LS3
-      shell: bash
-      run: ls -al ; ls -al .. ; ls -al api-wpvip-com
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -25,7 +25,7 @@ inputs:
   working-directory:
     description: 'Working directory when running NPM install'
     required: false
-    default: .
+    default: '.'
 
 runs:
   using: composite

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -32,7 +32,7 @@ runs:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
         sparse-checkout: ${{ inputs.working-directory != '.' && inputs.working-directory || null }}
-        sparse-checkout-cone-mode: false
+        sparse-checkout-cone-mode: false # Only used if sparse-checkout is non-null.
 
     - name: LS
       shell: bash
@@ -45,7 +45,7 @@ runs:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}
         cache: npm
-        cache-dependency-path: ${{ inputs.working-directory }}
+        cache-dependency-path: ${{ inputs.working-directory != '.' && inputs.working-directory || '' }}
 
     - name: LS2
       shell: bash

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: LS
       shell: bash
-      run: ls -al ; ls -al ..
+      run: ls -al ; ls -al .. ; ls -al api-wpvip-com
 
     - name: Set up Node.js environment using supplied Node.js version
       id: setup-node

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -35,7 +35,7 @@ runs:
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}
-        sparse-checkout: ${{ inputs.sparse-checkout }}
+        sparse-checkout: ${{ inputs.working-directory != '.' && inputs.working-directory || null }}
         sparse-checkout-cone-mode: false
 
     - name: LS

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Do a sparse checkout on given patterns'
     required: false
     default: null
+  working-directory:
+    description: 'Working directory when running NPM install'
+    required: false
+    default: './'
 
 runs:
   using: composite
@@ -51,5 +55,5 @@ runs:
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: npm ci ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
+      run: cd ${{ inputs.working-directory }} && npm ci ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
       shell: bash

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -53,7 +53,7 @@ runs:
       uses: actions/cache@v4
       id: cache-node-modules
       with:
-        path: ${{ inputs.working-directory }}/node_modules
+        path: node_modules
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -18,10 +18,6 @@ inputs:
   ignore-scripts:
     description: 'Ignore scripts when installing dependencies'
     required: false
-  sparse-checkout:
-    description: 'Do a sparse checkout on given patterns'
-    required: false
-    default: null
   working-directory:
     description: 'Working directory when running NPM install'
     required: false

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -53,10 +53,10 @@ runs:
       uses: actions/cache@v4
       id: cache-node-modules
       with:
-        path: node_modules
+        path: ${{ inputs.working-directory }}/node_modules
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: cd ${{ inputs.working-directory }} && npm ci ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
+      run: cd ${{ inputs.working-directory }}/ && npm ci ${{ inputs.ignore-scripts == 'true' && '--ignore-scripts' || '' }}
       shell: bash

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Ignore scripts when installing dependencies'
     required: false
   working-directory:
-    description: 'Effectively focuses checkout to this directory and uses as a working directory when running NPM install'
+    description: 'Effectively limits checkout to this directory and uses as a working directory when running NPM install'
     required: false
     default: '.'
 

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -55,6 +55,7 @@ runs:
       id: cache-node-modules
       with:
         path: ${{ inputs.working-directory }}/node_modules
+        cache-dependency-path: ${{ inputs.working-directory }}
         key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies


### PR DESCRIPTION
Adds an optional `working-directory` parameter. With this parameter set, checkout is limited to the specified directory and it is used as a working directory when installing NPM dependencies. This enables the setup of Node applications that live inside a sub-directory inside a repository.