### PR TITLE
nodejs-setup: Fix caching issue

### DIFF
--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -48,7 +48,7 @@ runs:
       id: cache-node-modules
       with:
         path: ${{ inputs.working-directory }}/node_modules
-        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
+        key: ${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ inputs.working-directory }}-${{ hashFiles('package.json', 'package-lock.json', 'npm-shrinkwrap.json') }}
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR fixes a small caching issue with the `nodejs-setup` action which can lead to old dependencies to be used.