### PR TITLE
Allow passing the wp category to the changelog script

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,6 +11,7 @@ For more info about the tool it uses under the hood, see: https://github.com/Aut
   * `repo-token`: the GitHub token required to retrieve pull requests. By default, `github.token` is used. Please make sure that the provided token has the `pull-requests: read` permission.
   * `status`: the status of the post to be published. Can be either `publish` (the default) or `draft`.
   * `tag-id`: the ID of a tag to be added to the post, empty by default. Can be a comma-separated list of tag IDs.
+  * `category-id`: the ID of a category to be added to the post, empty by default. Can be a comma-separated list of category IDs.
   * `link-to-pr`: whether to add a link to the pull request to the changelog post, `false` by default.
 
 #### Example

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'The id of a tag to be added to the post.'
     required: false
     default: ''
+  category-id:
+    description: 'The id of a category to be added to the post.'
+    required: false
+    default: ''
   link-to-pr:
     description: 'Wether to add a link to the Pull Request to the changelog post.'
     required: false
@@ -43,6 +47,7 @@ runs:
           --wp-endpoint='${{ inputs.endpoint }}' \
           --wp-status='${{ inputs.status }}' \
           --wp-tag-ids='${{ inputs.tag-id }}' \
+          --wp-categories='${{ inputs.category-id }}' \
           --link-to-pr='${{ inputs.link-to-pr }}'
       shell: bash
       env:


### PR DESCRIPTION
## Description

So that a changelog post can be assigned to the correct category, we need to be able to set the category ID when using this action in a workflow.

The changelog script already supports this param so we are just passing it through:
https://github.com/Automattic/vip-build-tools/blob/7de96cb69d35d2c20589e473c40a29e1d56ab829/scripts/github-changelog.php#L32