### PR TITLE
Changelogs: Update build tools to 1.1.0

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -13,6 +13,7 @@ For more info about the tool it uses under the hood, see: https://github.com/Aut
   * `tag-id`: the ID of a tag to be added to the post, empty by default. Can be a comma-separated list of tag IDs.
   * `category-id`: the ID of a category to be added to the post, empty by default. Can be a comma-separated list of category IDs.
   * `link-to-pr`: whether to add a link to the pull request to the changelog post, `false` by default.
+  * `changelog-source`: source of the changelog description. For example, we can get changelog from the last release or last PR. Default is last PR but `last-release` can be provided to use aggregate PRs comprising the last release.
 
 #### Example
 

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -42,7 +42,7 @@ runs:
         php-version: "7.4"
 
     - name: Installs automattic/vip-build-tools
-      run: composer require automattic/vip-build-tools:dev-update/improve-reusability-across-repos
+      run: composer require automattic/vip-build-tools:1.1.0
       shell: bash
 
     - name: Publishes the changelog

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Wether to add a link to the Pull Request to the changelog post.'
     required: false
     default: 'false'
+  source:
+    description: 'The source of the changelog.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -48,7 +52,8 @@ runs:
           --wp-status='${{ inputs.status }}' \
           --wp-tag-ids='${{ inputs.tag-id }}' \
           --wp-categories='${{ inputs.category-id }}' \
-          --link-to-pr='${{ inputs.link-to-pr }}'
+          --link-to-pr='${{ inputs.link-to-pr }}' \
+          --changelog-source='${{ inputs.source }}'
       shell: bash
       env:
         CHANGELOG_POST_TOKEN: ${{ inputs.endpoint-token }}

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -38,7 +38,7 @@ runs:
         php-version: "7.4"
 
     - name: Installs automattic/vip-build-tools
-      run: composer require automattic/vip-build-tools:1.0.6
+      run: composer require automattic/vip-build-tools:dev-update/improve-reusability-across-repos
       shell: bash
 
     - name: Publishes the changelog


### PR DESCRIPTION
## Description

Updates the changelog action to use the latest `vip-build-tools` tag.

## Testing instructions

- Give yourself access to the repo for site 4812
- Navigate to /actions/workflows/changelog.yml in that repo - the workflow is configured to use this branch.
- Choose `last-release` as the source from the workflow options
- Trigger the workflow and verify that it runs successfully
- Unset the source option and run the workflow again
- Verify it runs and succeeds
 