### PR TITLE
Changelogs: Update `vip-build-tools` to 1.2.0

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@ For more info about the tool it uses under the hood, see: https://github.com/Aut
 
   * `endpoint`: the endpoint to post the changelog; `https://public-api.wordpress.com/wp/v2/sites/vipinternalchangelog.wordpress.com/posts` by default;
   * `endpoint-token`: the WordPress token required to post to the given `endpoint`. **Required**.
+  * `endpoint-auth-type`: the authentication type to use for the endpoint. Can be either `bearer` (the default) or `basic`.
   * `repo-token`: the GitHub token required to retrieve pull requests. By default, `github.token` is used. Please make sure that the provided token has the `pull-requests: read` permission.
   * `status`: the status of the post to be published. Can be either `publish` (the default) or `draft`.
   * `tag-id`: the ID of a tag to be added to the post, empty by default. Can be a comma-separated list of tag IDs.

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -46,7 +46,7 @@ runs:
         php-version: "7.4"
 
     - name: Installs automattic/vip-build-tools
-      run: composer require automattic/vip-build-tools:dev-vipdoc-519/add/support-release-prs
+      run: composer require automattic/vip-build-tools:1.2.0
       shell: bash
 
     - name: Publishes the changelog

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -9,6 +9,10 @@ inputs:
   endpoint-token:
     description: 'The WordPress token required in order to post to the WordPress endpoint.'
     required: true
+  endpoint-auth-type:
+    description: 'The authentication type to use. Can be either "bearer" or "basic".'
+    required: false
+    default: 'bearer'
   repo-token:
     description: 'The GitHub token required in order to retrieve Pull Requests.'
     required: false
@@ -57,6 +61,7 @@ runs:
       shell: bash
       env:
         CHANGELOG_POST_TOKEN: ${{ inputs.endpoint-token }}
+        CHANGELOG_POST_AUTH_TYPE: ${{ inputs.endpoint-auth-type }}
         GITHUB_TOKEN: ${{ inputs.repo-token }}
         CIRCLE_PROJECT_USERNAME: ${{ github.repository_owner }}
         CIRCLE_PROJECT_REPONAME: ${{ github.event.repository.name }}

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -42,7 +42,7 @@ runs:
         php-version: "7.4"
 
     - name: Installs automattic/vip-build-tools
-      run: composer require automattic/vip-build-tools:1.1.0
+      run: composer require automattic/vip-build-tools:dev-vipdoc-519/add/support-release-prs
       shell: bash
 
     - name: Publishes the changelog
@@ -61,3 +61,4 @@ runs:
         CIRCLE_PROJECT_USERNAME: ${{ github.repository_owner }}
         CIRCLE_PROJECT_REPONAME: ${{ github.event.repository.name }}
         CIRCLE_SHA1: ${{ github.sha }}
+        GITHUB_BRANCH: ${{ github.ref_name }}

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -61,4 +61,4 @@ runs:
         CIRCLE_PROJECT_USERNAME: ${{ github.repository_owner }}
         CIRCLE_PROJECT_REPONAME: ${{ github.event.repository.name }}
         CIRCLE_SHA1: ${{ github.sha }}
-        GITHUB_BRANCH: ${{ github.ref_name }}
+        GITHUB_BASE_BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
## Description

Updates the changelog action to use the latest vip-build-tools tag.

### Testing instructions

- Give yourself access to the repo for site 4812
- Navigate to `/actions/workflows/changelog.yml` in that repo - the workflow is configured to use this branch.
- Choose last-release as the source from the workflow options
- Trigger the workflow and verify that it runs successfully
- Unset the source option and run the workflow again
- Verify it runs and succeeds