### PR TITLE
fix: use `github.token` instead of `secrets.GITHUB_TOKEN`

### DIFF
--- a/ai-changelog/action.yml
+++ b/ai-changelog/action.yml
@@ -7,7 +7,7 @@ inputs:
   token:
     description: The GitHub token for authentication.
     required: true
-    default: ${{ secrets.GITHUB_TOKEN }}
+    default: ${{ github.token }}
   openai_api_key:
     description: OpenAI API key for authentication.
     required: true


### PR DESCRIPTION
This pull request makes a small change to the `ai-changelog/action.yml` file, updating the default value for the `token` input to use `${{ github.token }}` instead of `${{ secrets.GITHUB_TOKEN }}`.

Ref: https://github.com/Automattic/vip-codespaces/actions/runs/16346505159
