### PR TITLE
feat: add prompt input for customizable changelog generation

### DIFF
--- a/ai-changelog/action.yml
+++ b/ai-changelog/action.yml
@@ -22,6 +22,9 @@ inputs:
   pr_description:
     description: The description to use instead of the original PR description.
     required: false
+  prompt:
+    description: Override the prompt used for generating the changelog entry.
+    required: false
 outputs:
   changelog_entry:
     description: The generated changelog entry.

--- a/ai-changelog/src/index.js
+++ b/ai-changelog/src/index.js
@@ -7,6 +7,7 @@ function getParams() {
 	const what = getInput( 'analyze' ) || 'diff';
 	const model = getInput( 'model' ) || 'gpt-4-turbo';
 	const description = getInput( 'pr_description' ) ?? '';
+	const prompt = getInput( 'prompt' ) ?? '';
 	const token = getInput( 'token' ) || env.GITHUB_TOKEN;
 	const openAiKey = getInput( 'openai_api_key' ) || env.OPENAI_API_KEY;
 
@@ -33,6 +34,7 @@ function getParams() {
 		what,
 		model,
 		description,
+		prompt,
 	};
 }
 
@@ -112,9 +114,10 @@ async function getPullRequestDiff( octokit, owner, repo, prNumber, format ) {
  * @param {number}                        prNumber
  * @param {string}                        what
  * @param {string}                        overriddenDescription
+ * @param {string}                        overriddenPrompt
  * @return {Promise<string>} Prompt
  */
-async function getPrompt( octokit, owner, repo, prNumber, what, overriddenDescription ) {
+async function getPrompt( octokit, owner, repo, prNumber, what, overriddenDescription, overriddenPrompt ) {
 	const template = `You are assisting in generating a changelog entry from a pull request.
 Given the pull request title, description, and diff, write a single Markdown list item summarizing the change.
 
@@ -147,7 +150,9 @@ Input:
 		}
 	}
 
-	return `${ template }\n${ title }\n\n${ description }\n\n${ info }`;
+	const instructions = overriddenPrompt || template;
+
+	return `${ instructions }\n${ title }\n\n${ description }\n\n${ info }`;
 }
 
 /**
@@ -176,18 +181,18 @@ async function askOpenAI( prompt, openAiKey, model ) {
 
 async function run() {
 	try {
-		const { prNumber, token, openAiKey, what, model, description } = getParams();
+		const { prNumber, token, openAiKey, what, model, description, prompt: overriddenPrompt } = getParams();
 		const { owner, repo } = context.repo;
 		const octokit = getOctokit( token );
 
-		let prompt = await getPrompt( octokit, owner, repo, prNumber, what, description );
+		let prompt = await getPrompt( octokit, owner, repo, prNumber, what, description, overriddenPrompt );
 
 		let changelogEntry = await askOpenAI( prompt, openAiKey, model );
 		if ( ! changelogEntry ) {
 			warning( 'No content returned from OpenAI' );
 			if ( what !== 'commits' ) {
 				debug( 'Retrying in `commits` mode' );
-				prompt = await getPrompt( octokit, owner, repo, prNumber, 'commits', description );
+				prompt = await getPrompt( octokit, owner, repo, prNumber, 'commits', description, overriddenPrompt );
 				debug( `Generated prompt: ${ prompt }` );
 				changelogEntry = await askOpenAI( prompt, openAiKey, model );
 				if ( ! changelogEntry ) {


### PR DESCRIPTION
This pull request introduces a new feature allowing users to override the default prompt used for generating changelog entries. The changes involve updates to both the `action.yml` configuration and the `index.js` script to support this functionality.

### Enhancements to prompt customization:

* **`ai-changelog/action.yml`:** Added a new optional input parameter, `prompt`, which allows users to specify a custom prompt for generating the changelog entry.

* **`ai-changelog/src/index.js`:** Updated the `getParams` function to retrieve the new `prompt` input parameter. [[1]](diffhunk://#diff-758946c5071c3e85329d1dfa0b3b5398ef738a2179a777ca621cf078b26cf65aR10) [[2]](diffhunk://#diff-758946c5071c3e85329d1dfa0b3b5398ef738a2179a777ca621cf078b26cf65aR37)

* **`ai-changelog/src/index.js`:** Modified the `getPrompt` function to accept and use the `overriddenPrompt` parameter, falling back to the default template if not provided. [[1]](diffhunk://#diff-758946c5071c3e85329d1dfa0b3b5398ef738a2179a777ca621cf078b26cf65aR117-R120) [[2]](diffhunk://#diff-758946c5071c3e85329d1dfa0b3b5398ef738a2179a777ca621cf078b26cf65aL150-R155)

* **`ai-changelog/src/index.js`:** Updated the `run` function to pass the `overriddenPrompt` parameter throughout the workflow, ensuring the custom prompt is utilized when specified.