### PR TITLE
chore(ci): update `actions/checkout` to v5

### DIFF
--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       if: ${{ inputs.SKIP_CHECKOUT != 'true' }}
 
     - name: Setup Node

--- a/dependaban/action.yml
+++ b/dependaban/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         persist-credentials: false
 

--- a/git-hash-security-check/action.yml
+++ b/git-hash-security-check/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Verify Full Git Commit Hashes
       shell: bash

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ inputs.ref }}

--- a/npm-prepare-release/action.yml
+++ b/npm-prepare-release/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/npm-publish-prerelease/action.yml
+++ b/npm-publish-prerelease/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node
       uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows across multiple action configuration files to use the latest version of the `actions/checkout` action. This change ensures improved performance, security, and compatibility with the newest features and bug fixes provided by version 5 of the action.

**Workflow dependency updates:**

* Updated `actions/checkout` from version 4 to version 5 in `custom-deployment/action.yml` (`runs:` section).
* Updated `actions/checkout` from version 4 to version 5 in `dependaban/action.yml` (`runs:` section).
* Updated `actions/checkout` from version 4 to version 5 in `git-hash-security-check/action.yml` (`runs:` section).
* Updated `actions/checkout` from version 4 to version 5 in `nodejs-setup/action.yml` (`runs:` section).

**Node.js and npm workflows:**

* Updated `actions/checkout` from version 4 to version 5 in `npm-prepare-release/action.yml`, `npm-publish-prerelease/action.yml`, and `npm-publish/action.yml` (`runs:` sections). [[1]](diffhunk://#diff-c9193898422b62c5dea353e65eb51cd1c3cd53ef873194854783d30709ec55fdL33-R33) [[2]](diffhunk://#diff-7889e5fce9ae08c5dacc4eccb631a28051ff8d2fdc6936c145da36430a390f2eL26-R26) [[3]](diffhunk://#diff-6109a8dbedc5762a599893233286d8887ec7285038cd020bfd5e4f5a8b7694c6L33-R33)