### PR TITLE
chore(dev-deps): update `typescript` to 5.9.2

### DIFF
--- a/coverage-pr-comment/package-lock.json
+++ b/coverage-pr-comment/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^24.1.0",
         "@vercel/ncc": "^0.38.3",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=20"
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/coverage-pr-comment/package.json
+++ b/coverage-pr-comment/package.json
@@ -27,6 +27,6 @@
   "devDependencies": {
     "@types/node": "^24.1.0",
     "@vercel/ncc": "^0.38.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/sticky-pr-comment/package-lock.json
+++ b/sticky-pr-comment/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/node": "^24.1.0",
         "@vercel/ncc": "^0.38.3",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@actions/core": {
@@ -372,9 +372,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/sticky-pr-comment/package.json
+++ b/sticky-pr-comment/package.json
@@ -26,6 +26,6 @@
   "devDependencies": {
     "@types/node": "^24.1.0",
     "@vercel/ncc": "^0.38.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
This pull request updates the TypeScript dependency to version 5.9.2 across both the `coverage-pr-comment` and `sticky-pr-comment` packages. This ensures consistency and access to the latest features and bug fixes in TypeScript.

Dependency updates:

* Updated the `typescript` version from 5.8.3 to 5.9.2 in `coverage-pr-comment/package.json` and `sticky-pr-comment/package.json` to use the latest TypeScript release. [[1]](diffhunk://#diff-9dd2332e349df85d653692146a03e1b8e90cd413dfa9a64df0f31c960661887eL30-R30) [[2]](diffhunk://#diff-05b092027861674012b2ee4e7809ab8be30d4606725c4fe2d115a1dbda35bccbL29-R29)
* Updated the TypeScript package details in `coverage-pr-comment/package-lock.json` and `sticky-pr-comment/package-lock.json`, including the resolved version and integrity hash. [[1]](diffhunk://#diff-6aa3adbda701167b83056d7c545521564ca3f55f5ea1ea5ea9c49b81a3be9359L18-R18) [[2]](diffhunk://#diff-6aa3adbda701167b83056d7c545521564ca3f55f5ea1ea5ea9c49b81a3be9359L278-R280) [[3]](diffhunk://#diff-0150aca836ce3f67adb40b7c99f3c661d9558ac9c0bc682786bb06ec984a894fL20-R20) [[4]](diffhunk://#diff-0150aca836ce3f67adb40b7c99f3c661d9558ac9c0bc682786bb06ec984a894fL375-R377)