### PR TITLE
fix: update Node.js version to use LTS and enable caching

### DIFF
--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -51,7 +51,8 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4.4.0
       with:
-        node-version: "v20.11.1"
+        node-version: lts/*
+        cache: npm
 
     - name: Install VIP CLI
       run: |


### PR DESCRIPTION
This pull request updates the Node.js setup step in the `custom-deployment/action.yml` workflow file. The workflow now uses the latest LTS version of Node.js and enables npm caching to improve build performance.

Workflow improvements:

* Updated the `node-version` input in the `actions/setup-node` step to use `lts/*` instead of a specific version, ensuring the workflow always runs on the latest LTS release.
* Enabled npm caching by adding the `cache: npm` option to the Node.js setup step, which can speed up dependency installation.