### PR TITLE
ci: update `actions/setup-node` to `v6` everywhere

### DIFF
--- a/custom-deployment/action.yml
+++ b/custom-deployment/action.yml
@@ -49,7 +49,7 @@ runs:
       if: ${{ inputs.SKIP_CHECKOUT != 'true' }}
 
     - name: Setup Node
-      uses: actions/setup-node@v5.0.0
+      uses: actions/setup-node@v6.0.0
       with:
         node-version: lts/*
         cache: npm

--- a/dependaban/action.yml
+++ b/dependaban/action.yml
@@ -18,7 +18,7 @@ runs:
         persist-credentials: false
 
     - name: Set up Node.js envirtonment
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: "lts/*"
         cache: npm

--- a/nodejs-setup/action.yml
+++ b/nodejs-setup/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Set up Node.js environment using supplied Node.js version
       id: setup-node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version-file }}

--- a/npm-prepare-release/action.yml
+++ b/npm-prepare-release/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: actions/checkout@v5
 
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: https://registry.npmjs.org/

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: actions/checkout@v5
 
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest major version of the `actions/setup-node` action, moving from version 5 to version 6. This ensures that all workflows benefit from the latest features, bug fixes, and security improvements provided by the updated action.

**Continuous Integration/Deployment workflow updates:**

* Updated the Node.js setup step in `custom-deployment/action.yml` to use `actions/setup-node@v6.0.0` instead of `v5.0.0`.
* Updated the Node.js setup step in `dependaban/action.yml` to use `actions/setup-node@v6` instead of `v5`.
* Updated the Node.js setup step in `nodejs-setup/action.yml` to use `actions/setup-node@v6` instead of `v5`.
* Updated the Node.js setup step in `npm-prepare-release/action.yml` to use `actions/setup-node@v6` instead of `v5`.
* Updated the Node.js setup step in `npm-publish/action.yml` to use `actions/setup-node@v6` instead of `v5`.