### PR TITLE
Add support for custom changelog titles

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,7 +16,7 @@ For more info about the tool it uses under the hood, see: https://github.com/Aut
   * `terms`: the taxonomy, and term IDs to be added to the post. For example `custom_taxonomy_slug:1,2`
   * `link-to-pr`: whether to add a link to the pull request to the changelog post, `false` by default.
   * `changelog-source`: source of the changelog description. For example, we can get changelog from the last release or last PR. Default is last PR but `last-release` can be provided to use aggregate PRs comprising the last release.
-  * `changelog-title`: custom title format for the changelog post. Supports placeholders: `{date}`, `{datetime}`, `{pr}`, `{version}`, `{repo}`. Empty by default.
+  * `changelog-title`: custom title format for the changelog post. Supports placeholders: `{date}`, `{datetime}`, `{pr}`, `{version}`, `{repo}`.
 
 #### Example
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,6 +16,7 @@ For more info about the tool it uses under the hood, see: https://github.com/Aut
   * `terms`: the taxonomy, and term IDs to be added to the post. For example `custom_taxonomy_slug:1,2`
   * `link-to-pr`: whether to add a link to the pull request to the changelog post, `false` by default.
   * `changelog-source`: source of the changelog description. For example, we can get changelog from the last release or last PR. Default is last PR but `last-release` can be provided to use aggregate PRs comprising the last release.
+  * `changelog-title`: custom title format for the changelog post. Supports placeholders: `{date}`, `{datetime}`, `{pr}`, `{version}`, `{repo}`. Empty by default.
 
 #### Example
 

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -54,7 +54,7 @@ runs:
         php-version: "7.4"
 
     - name: Installs automattic/vip-build-tools
-      run: composer require automattic/vip-build-tools:1.3.0
+      run: composer require automattic/vip-build-tools:1.4.0
       shell: bash
 
     - name: Publishes the changelog

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'The terms to be added to the post.'
     required: false
     default: ''
+  changelog-title:
+    description: 'The title of the changelog post.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -62,7 +66,8 @@ runs:
           --wp-categories='${{ inputs.category-id }}' \
           --wp-terms='${{ inputs.terms }}' \
           --link-to-pr='${{ inputs.link-to-pr }}' \
-          --changelog-source='${{ inputs.source }}'
+          --changelog-source='${{ inputs.source }}' \
+          --changelog-title='${{ inputs.changelog-title }}'
       shell: bash
       env:
         CHANGELOG_POST_TOKEN: ${{ inputs.endpoint-token }}


### PR DESCRIPTION
### Description

This pull request adds support for customizing the changelog post title format. Switching to the `vip-build-tools` 1.4.0 tag also brings the benefit of better sanitized changelog HTML.

Changelog customization:

* Added a new input parameter `changelog-title` to `action.yml`, allowing users to specify a custom title format for the changelog post, with support for placeholders such as `{date}`, `{datetime}`, `{pr}`, `{version}`, and `{repo}`. [[1]](diffhunk://#diff-ad6be67306bf6870856c59121a102878d09b02d05ec3d84d8924eb3b7f36a1b1R44-R47) [[2]](diffhunk://#diff-861d0d6527afefde8a5f11cd0baad47e651931f7424b83462f0f66875afde016R19)
* Updated the changelog publishing step to pass the `--changelog-title` argument to the build tool, enabling the use of the custom title format.

Dependency update:

* Updated the `composer require` command in `action.yml` to use `automattic/vip-build-tools` version 1.4.0 (previously 1.3.0), ensuring compatibility with new features.

RE: https://github.com/Automattic/vip-build-tools/releases/tag/1.4.0