### PR TITLE
fix: stage npm artifacts without preserving hard links

### DIFF
--- a/.github/workflows/npm-pack-staged.yml
+++ b/.github/workflows/npm-pack-staged.yml
@@ -1,0 +1,28 @@
+name: Test staged npm packaging
+on:
+  pull_request:
+    paths:
+      - 'npm-pack-staged/**'
+      - 'npm-publish/**'
+      - 'npm-publish-prerelease/**'
+      - '.github/workflows/npm-pack-staged.yml'
+  push:
+    branches: [trunk]
+    paths:
+      - 'npm-pack-staged/**'
+      - 'npm-publish/**'
+      - 'npm-publish-prerelease/**'
+      - '.github/workflows/npm-pack-staged.yml'
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - run: npm install --global npm@11
+      - run: shellcheck npm-pack-staged/bin/pack.sh npm-publish/bin/publish.sh npm-publish-prerelease/bin/publish.sh
+      - run: python3 -m unittest discover -s npm-pack-staged/tests -v

--- a/npm-pack-staged/README.md
+++ b/npm-pack-staged/README.md
@@ -1,0 +1,39 @@
+# Pack a staged npm artifact
+
+Use after installing dependencies, building and testing the package. Requires
+Node/npm, `rsync`, Python 3 and `tar` (available on GitHub-hosted Ubuntu runners).
+This action never publishes.
+
+The helper runs `prepublishOnly`, `prepack` and `prepare` in the source checkout
+with the registry token cleared. It uses `rsync -a` **without `-H`** into a fresh
+temporary directory, then packs with lifecycle scripts disabled. It validates
+package identity and rejects links, duplicate paths and unsafe archive entries.
+`postpack` runs in the source checkout after packing. Optional smoke tests run
+inside an extraction of the validated archive; dependencies must be bundled for
+these tests. Smoke tests must be non-mutating checks of the artifact.
+
+`tarball` is an absolute path to the validated artifact under `RUNNER_TEMP`.
+Publish that exact file with `npm publish "$TARBALL" --ignore-scripts` and the
+appropriate tag/provenance flags. Do not rebuild, repack or publish the directory
+after validation. Publishing the tarball intentionally does not run directory
+`publish`/`postpublish` hooks; consumers needing those hooks should retain the
+legacy publishing path until they move that work into explicit workflow steps.
+The staging directory is always cleaned; the action's output remains for later
+steps until the job's temporary directory is removed.
+
+Both `npm-publish` and `npm-publish-prerelease` support `STAGE_PACKAGE: 'true'`
+with optional `SMOKE_SCRIPT`. Their default remains the legacy directory publish
+path so other consumers opt in explicitly. For VIP CLI, use `SMOKE_SCRIPT:
+smoke:release`.
+
+Run regression checks without registry access or publication:
+
+```sh
+python3 -m unittest discover -s npm-pack-staged/tests -v
+shellcheck npm-pack-staged/bin/pack.sh npm-publish/bin/publish.sh npm-publish-prerelease/bin/publish.sh
+```
+
+Tests build real fixture tarballs and exercise both publisher scripts with
+mocked publishing. They cover link flattening, preserved bytes and modes,
+lifecycle ordering, smoke failures, archive rejection, and publishing the same
+bytes used by the dry run.

--- a/npm-pack-staged/action.yml
+++ b/npm-pack-staged/action.yml
@@ -1,0 +1,26 @@
+name: Pack npm package from a fresh staging directory
+description: Copy built dependencies without hard links, pack once, validate and optionally smoke-test the artifact. Does not publish.
+inputs:
+  tag:
+    description: npm tag used by prepublish validation
+    default: latest
+  smoke-script:
+    description: Optional npm script to run inside the extracted tarball (dependencies must be bundled)
+    default: ''
+outputs:
+  tarball:
+    description: Absolute path to the validated tarball
+    value: ${{ steps.pack.outputs.tarball }}
+runs:
+  using: composite
+  steps:
+    - id: pack
+      shell: bash
+      env:
+        PACK_SCRIPT: ${{ github.action_path }}/bin/pack.sh
+        PACK_TAG: ${{ inputs.tag }}
+        SMOKE_SCRIPT: ${{ inputs.smoke-script }}
+      run: |
+        output_dir=$(mktemp -d "$RUNNER_TEMP/npm-artifact.XXXXXXXX")
+        tarball=$(bash "$PACK_SCRIPT" "$GITHUB_WORKSPACE" "$output_dir" "$PACK_TAG" "$SMOKE_SCRIPT")
+        printf 'tarball=%s\n' "$tarball" >> "$GITHUB_OUTPUT"

--- a/npm-pack-staged/bin/pack.sh
+++ b/npm-pack-staged/bin/pack.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# stdout is exclusively the validated tarball path. All build output goes to stderr.
+set -euo pipefail
+
+source_dir=$(cd "${1:-.}" && pwd -P)
+output_dir=$(cd "${2:?Provide an existing output directory outside the source tree}" && pwd -P)
+tag=${3:-latest}
+smoke_script=${4:-}
+case "$output_dir/" in
+  "$source_dir/"*) echo 'Output directory must be outside the source tree.' >&2; exit 1 ;;
+esac
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/npm-pack-staged.XXXXXXXX")
+trap 'rm -rf "$work_dir"' EXIT
+case "$work_dir/" in
+  "$source_dir/"*) echo 'TMPDIR must be outside the source tree.' >&2; exit 1 ;;
+esac
+
+# Preserve validation/pack hooks, but run all artifact-producing hooks before copying.
+# Never expose the registry token to lifecycle scripts or smoke tests.
+export NODE_AUTH_TOKEN=''
+export NPM_CONFIG_LOGLEVEL=error
+export npm_config_tag="$tag"
+cd "$source_dir"
+npm run prepublishOnly --if-present >&2
+npm run prepack --if-present >&2
+npm run prepare --if-present >&2
+
+mkdir "$work_dir/package"
+# -a intentionally omits -H: every hard-linked name becomes an independent file.
+# A fresh destination is essential; updating an old staging tree is not sufficient.
+rsync -a --exclude='/.git' --exclude='/.npmrc' "$source_dir/" "$work_dir/package/"
+(
+  cd "$work_dir/package"
+  npm pack --ignore-scripts --json --pack-destination "$work_dir" > "$work_dir/pack.json"
+)
+filename=$(node -e 'const p = require(process.argv[1]); if (p.length !== 1 || require("node:path").basename(p[0].filename) !== p[0].filename) process.exit(1); process.stdout.write(p[0].filename);' "$work_dir/pack.json")
+archive="$work_dir/$filename"
+python3 "$script_dir/validate.py" "$archive" "$source_dir/package.json" >&2
+npm run postpack --if-present >&2
+
+if [[ -n "$smoke_script" ]]; then
+  mkdir "$work_dir/smoke"
+  tar -xzf "$archive" -C "$work_dir/smoke"
+  # Run against the extracted artifact, not the original checkout or staging tree.
+  (cd "$work_dir/smoke/package" && npm run "$smoke_script") >&2
+fi
+
+# Only expose a completed, validated artifact. The caller owns output_dir cleanup.
+if [[ -e "$output_dir/$filename" ]]; then
+  echo "Refusing to overwrite an existing artifact: $output_dir/$filename" >&2
+  exit 1
+fi
+cp "$archive" "$output_dir/$filename"
+printf '%s\n' "$output_dir/$filename"

--- a/npm-pack-staged/bin/validate.py
+++ b/npm-pack-staged/bin/validate.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Reject links/unsafe entries and verify the identity of an npm artifact."""
+import json
+import sys
+import tarfile
+from pathlib import PurePosixPath
+
+
+def validate(archive, manifest):
+    with open(manifest, encoding="utf-8") as source:
+        expected = json.load(source)
+    seen = set()
+    packed = None
+    with tarfile.open(archive, "r:gz") as package:
+        for entry in package:
+            path = PurePosixPath(entry.name)
+            if (path.is_absolute() or ".." in path.parts or not path.parts
+                    or path.parts[0] != "package" or path.as_posix() in seen):
+                raise ValueError(f"Unsafe or duplicate archive entry: {entry.name}")
+            seen.add(path.as_posix())
+            if entry.islnk() or entry.issym():
+                raise ValueError(f"Forbidden archive link: {entry.name} -> {entry.linkname}")
+            if not (entry.isfile() or entry.isdir()):
+                raise ValueError(f"Unsupported archive entry: {entry.name}")
+            if entry.name == "package/package.json":
+                packed = json.load(package.extractfile(entry))
+    if not packed or any(packed.get(k) != expected.get(k) for k in ("name", "version")):
+        raise ValueError("Archive package name/version does not match the source")
+    print(f"Validated {packed['name']}@{packed['version']}: {len(seen)} entries, no links")
+
+
+if __name__ == "__main__":
+    validate(*sys.argv[1:])

--- a/npm-pack-staged/tests/test_pack.py
+++ b/npm-pack-staged/tests/test_pack.py
@@ -1,0 +1,190 @@
+import importlib.util
+import io
+import json
+import os
+import shutil
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location('validator', ROOT / 'bin/validate.py')
+validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validator)
+
+
+class StagedPackageTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix='npm staging test ')
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.source = self.root / 'source'
+        self.output = self.root / 'output'
+        self.source.mkdir()
+        self.output.mkdir()
+        self.manifest = {
+            'name': 'staging-fixture', 'version': '1.0.0',
+            'dependencies': {'native-fixture': '1.0.0'},
+            'bundleDependencies': True,
+            'scripts': {
+                'prepublishOnly': 'node -e "if(process.env.npm_config_tag!==\'next\')process.exit(1)"',
+                'prepare': 'node prepare.js',
+                'postpack': 'node -e "require(\'fs\').writeFileSync(\'built.txt\',\'changed-after-pack\')"',
+                'smoke': 'node smoke.js',
+                'test': 'node smoke.js',
+            },
+        }
+        (self.source / 'package.json').write_text(json.dumps(self.manifest))
+        dep = self.source / 'node_modules/native-fixture'
+        dep.mkdir(parents=True)
+        (dep / 'package.json').write_text(json.dumps({'name': 'native-fixture', 'version': '1.0.0'}))
+        (self.source / 'prepare.js').write_text('''
+const fs = require('fs');
+const dir = 'node_modules/native-fixture/';
+fs.writeFileSync('built.txt', 'built-before-copy');
+fs.writeFileSync(dir + 'original.node', 'native-bytes');
+fs.chmodSync(dir + 'original.node', 0o755);
+if (fs.existsSync(dir + 'copy.node')) fs.unlinkSync(dir + 'copy.node');
+fs.linkSync(dir + 'original.node', dir + 'copy.node');
+''')
+        (self.source / 'smoke.js').write_text('''
+const fs = require('fs');
+if (fs.readFileSync('built.txt', 'utf8') !== 'built-before-copy') process.exit(1);
+if (fs.readFileSync('node_modules/native-fixture/copy.node', 'utf8') !== 'native-bytes') process.exit(1);
+if (process.env.NODE_AUTH_TOKEN) process.exit(1);
+''')
+        self.env = {**os.environ, 'HOME': str(self.root), 'NODE_AUTH_TOKEN': 'must-not-reach-hooks',
+                    'NPM_CONFIG_USERCONFIG': os.devnull, 'NPM_CONFIG_CACHE': str(self.root / 'cache'),
+                    'NPM_CONFIG_REGISTRY': 'http://127.0.0.1:9', 'TMPDIR': str(self.root)}
+
+    def pack(self, smoke='smoke'):
+        return subprocess.run(['bash', str(ROOT / 'bin/pack.sh'), str(self.source), str(self.output),
+                               'next', smoke], env=self.env, text=True, capture_output=True)
+
+    def test_copies_links_and_smokes_exact_archive_without_rebuilding(self):
+        result = self.pack()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        archive = Path(result.stdout.strip())
+        self.assertEqual(archive.parent, self.output.resolve())
+        with tarfile.open(archive) as package:
+            self.assertFalse(any(m.islnk() or m.issym() for m in package))
+            for name in ['original.node', 'copy.node']:
+                member = package.getmember('package/node_modules/native-fixture/' + name)
+                self.assertTrue(member.isfile())
+                self.assertEqual(member.mode & 0o777, 0o755)
+                self.assertEqual(package.extractfile(member).read(), b'native-bytes')
+            self.assertEqual(package.extractfile('package/built.txt').read(), b'built-before-copy')
+        dep = self.source / 'node_modules/native-fixture'
+        self.assertEqual((dep / 'original.node').stat().st_ino, (dep / 'copy.node').stat().st_ino)
+        self.assertEqual((self.source / 'built.txt').read_text(), 'changed-after-pack')
+        self.assertEqual(list(self.root.glob('npm-pack-staged.*')), [])
+
+    def test_hook_failure_does_not_produce_an_artifact(self):
+        self.manifest['scripts']['prepublishOnly'] = 'node -e "process.exit(7)"'
+        (self.source / 'package.json').write_text(json.dumps(self.manifest))
+        self.assertNotEqual(self.pack().returncode, 0)
+        self.assertEqual(list(self.output.iterdir()), [])
+
+    def test_smoke_failure_does_not_produce_an_artifact(self):
+        (self.source / 'smoke.js').write_text('process.exit(8)')
+        self.assertNotEqual(self.pack().returncode, 0)
+        self.assertEqual(list(self.output.iterdir()), [])
+        self.assertEqual(list(self.root.glob('npm-pack-staged.*')), [])
+
+    def test_output_inside_source_is_rejected(self):
+        self.output = self.source
+        result = self.pack()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('outside the source', result.stderr)
+
+    def test_existing_artifact_is_not_overwritten(self):
+        artifact = self.output / 'staging-fixture-1.0.0.tgz'
+        artifact.write_bytes(b'keep-me')
+        self.assertNotEqual(self.pack().returncode, 0)
+        self.assertEqual(artifact.read_bytes(), b'keep-me')
+
+    def test_stable_and_prerelease_publish_the_exact_dry_run_artifact(self):
+        commands = self.root / 'commands'
+        commands.mkdir()
+        real_npm = shutil.which('npm')
+        for name, body in {
+            'git': '#!/bin/sh\ncase "$1" in branch) echo trunk ;; fetch|checkout|diff-index) ;; *) exit 9 ;; esac\n',
+            'gh': '#!/bin/sh\nif [ "$1 $2" = "pr diff" ]; then echo package.json; fi\n',
+            'npm': r'''#!/usr/bin/env python3
+import hashlib, json, os, subprocess, sys, tarfile
+args = sys.argv[1:]
+if args[0] == 'view':
+    print('0.9.0')
+elif args[0] in ('ci', 'rebuild'):
+    pass
+elif args[0] == 'publish':
+    artifact = args[1]
+    assert artifact.endswith('.tgz'), args
+    assert '--ignore-scripts' in args, args
+    with tarfile.open(artifact) as t:
+        assert not any(m.islnk() or m.issym() for m in t)
+    with open(artifact, 'rb') as f:
+        digest = hashlib.sha256(f.read()).hexdigest()
+    with open(os.environ['PUBLISH_LOG'], 'a') as f:
+        f.write(json.dumps({'args': args, 'sha256': digest}) + '\n')
+else:
+    sys.exit(subprocess.call([os.environ['REAL_NPM'], *args]))
+''',
+        }.items():
+            script = commands / name
+            script.write_text(body)
+            script.chmod(0o755)
+        # The stable action supplies latest; test the prerelease tag independently.
+        self.manifest['scripts']['prepublishOnly'] = 'node -e "if(process.env.NODE_AUTH_TOKEN)process.exit(1)"'
+        (self.source / 'package.json').write_text(json.dumps(self.manifest))
+        for action in ['npm-publish', 'npm-publish-prerelease']:
+            with self.subTest(action=action):
+                log = self.root / (action + '.jsonl')
+                env = {**self.env, 'PATH': str(commands) + os.pathsep + os.environ['PATH'],
+                       'REAL_NPM': real_npm, 'PUBLISH_LOG': str(log), 'CI': 'true',
+                       'GITHUB_ACTIONS': 'true', 'PROVENANCE': 'true',
+                       'USE_TRUSTED_PUBLISHING': 'true', 'STAGE_PACKAGE': 'true',
+                       'SMOKE_SCRIPT': 'smoke', 'SKIP_BUMP_TO_DEV': 'true',
+                       'PR_HEAD_REF': 'release/patch--trunk', 'PR_NUMBER': '1', 'NPM_TAG': 'next'}
+                result = subprocess.run(['bash', str(ROOT.parent / action / 'bin/publish.sh')],
+                                        cwd=self.source, env=env, text=True, capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                calls = [json.loads(line) for line in log.read_text().splitlines()]
+                self.assertEqual(len(calls), 2)
+                self.assertEqual(calls[0]['args'][1], calls[1]['args'][1])
+                self.assertEqual(calls[0]['sha256'], calls[1]['sha256'])
+                self.assertIn('--dry-run', calls[0]['args'])
+                self.assertNotIn('--dry-run', calls[1]['args'])
+                self.assertIn('--provenance', calls[1]['args'])
+                self.assertFalse(Path(calls[1]['args'][1]).exists(), 'temporary artifact must be cleaned')
+
+    def test_validator_rejects_unsafe_archives(self):
+        for name, kind, identity in [
+            ('package/hard.node', tarfile.LNKTYPE, self.manifest),
+            ('package/soft.node', tarfile.SYMTYPE, self.manifest),
+            ('package/../escape', tarfile.REGTYPE, self.manifest),
+            ('/absolute', tarfile.REGTYPE, self.manifest),
+            ('package/device', tarfile.CHRTYPE, self.manifest),
+            ('package/package.json', tarfile.REGTYPE, self.manifest),
+            ('package/safe', tarfile.REGTYPE, {'name': 'wrong', 'version': '1.0.0'}),
+        ]:
+            with self.subTest(name=name, kind=kind):
+                archive = self.output / 'bad.tgz'
+                with tarfile.open(archive, 'w:gz') as package:
+                    data = json.dumps(identity).encode()
+                    manifest = tarfile.TarInfo('package/package.json')
+                    manifest.size = len(data)
+                    package.addfile(manifest, io.BytesIO(data))
+                    entry = tarfile.TarInfo(name)
+                    entry.type = kind
+                    if kind in (tarfile.LNKTYPE, tarfile.SYMTYPE):
+                        entry.linkname = 'package/package.json'
+                    package.addfile(entry)
+                with self.assertRaises(ValueError):
+                    validator.validate(archive, self.source / 'package.json')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/npm-publish-prerelease/action.yml
+++ b/npm-publish-prerelease/action.yml
@@ -2,6 +2,12 @@
 name: Publish a prerelease version of the package to npm
 description: This action automates various aspects of publishing a package to the npm registry including running tests, versioning, and tagging.
 inputs:
+  STAGE_PACKAGE:
+    description: 'Pack from a fresh rsync copy and publish the validated tarball without rerunning hooks (requires rsync and Python 3).'
+    default: 'false'
+  SMOKE_SCRIPT:
+    description: 'Optional npm script to run inside the staged tarball; requires STAGE_PACKAGE and bundled dependencies.'
+    default: ''
   USE_TRUSTED_PUBLISHING:
     description: 'Is this package configured to use the npm OIDC-based Trusted Publishing feature?'
     required: false
@@ -63,6 +69,8 @@ runs:
       # @see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
       run: ${{ github.action_path }}/bin/publish.sh
       env:
+        STAGE_PACKAGE: ${{ inputs.STAGE_PACKAGE }}
+        SMOKE_SCRIPT: ${{ inputs.SMOKE_SCRIPT }}
         USE_TRUSTED_PUBLISHING: ${{ inputs.USE_TRUSTED_PUBLISHING }}
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         PROVENANCE: ${{ inputs.PROVENANCE }}

--- a/npm-publish-prerelease/bin/publish.sh
+++ b/npm-publish-prerelease/bin/publish.sh
@@ -65,10 +65,22 @@ if [ -t 0 ]; then
 	esac
 fi
 
-# Publish with Dry Run
-echo_title "npm publish (dry-run)"
-npm publish --access public --tag "${NPM_TAG}" --dry-run
-echo "✅ Dry run looks good"
+# Stage once after building/testing; retain the legacy path for other consumers.
+PACKAGE_TARBALL=''
+if [ "${STAGE_PACKAGE:-false}" = 'true' ]; then
+	echo_title "Pack and validate staged npm artifact"
+	artifact_dir=$(mktemp -d "${TMPDIR:-/tmp}/npm-publish-artifact.XXXXXXXX")
+	trap 'rm -rf "$artifact_dir"' EXIT
+	script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+	PACKAGE_TARBALL=$(bash "$script_dir/../../npm-pack-staged/bin/pack.sh" "$PWD" "$artifact_dir" "${NPM_TAG}" "${SMOKE_SCRIPT:-}")
+	npm publish "$PACKAGE_TARBALL" --access public --tag "${NPM_TAG}" --dry-run --ignore-scripts --loglevel error
+else
+	# Publish with Dry Run
+	echo_title "npm publish (dry-run)"
+	npm publish --access public --tag "${NPM_TAG}" --dry-run
+	echo "✅ Dry run looks good"
+
+fi
 
 # Publish on GitHub and tag
 echo_title "Publishing a new release on GitHub and tagging"
@@ -82,6 +94,11 @@ if [ "${PROVENANCE}" = "true" ] && [ "${CI:-}" = "true" ] && [ "${GITHUB_ACTIONS
 	OPTIONS="${OPTIONS} --provenance"
 fi
 
-# shellcheck disable=SC2086 # We want to pass the options as a string
-npm publish ${OPTIONS}
+if [ -n "$PACKAGE_TARBALL" ]; then
+	# shellcheck disable=SC2086 # OPTIONS contains the existing publish flags.
+	npm publish "$PACKAGE_TARBALL" ${OPTIONS} --ignore-scripts --loglevel error
+else
+	# shellcheck disable=SC2086 # OPTIONS contains the existing publish flags.
+	npm publish ${OPTIONS}
+fi
 echo "✅ Successfully published new release for ${LOCAL_NAME} as ${LOCAL_VERSION}"

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -3,6 +3,12 @@
 name: Publish package to npm
 description: This action automates various aspects of publishing a package to the npm registry including running tests, versioning, and tagging.
 inputs:
+  STAGE_PACKAGE:
+    description: 'Pack from a fresh rsync copy and publish the validated tarball without rerunning hooks (requires rsync and Python 3).'
+    default: 'false'
+  SMOKE_SCRIPT:
+    description: 'Optional npm script to run inside the staged tarball; requires STAGE_PACKAGE and bundled dependencies.'
+    default: ''
   USE_TRUSTED_PUBLISHING:
     description: 'Is this package configured to use the npm OIDC-based Trusted Publishing feature?'
     required: false
@@ -69,6 +75,8 @@ runs:
       # @see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsrun
       run: ${{ github.action_path }}/bin/publish.sh
       env:
+        STAGE_PACKAGE: ${{ inputs.STAGE_PACKAGE }}
+        SMOKE_SCRIPT: ${{ inputs.SMOKE_SCRIPT }}
         USE_TRUSTED_PUBLISHING: ${{ inputs.USE_TRUSTED_PUBLISHING }}
         GH_TOKEN: ${{ inputs.GH_TOKEN }}
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/npm-publish/bin/publish.sh
+++ b/npm-publish/bin/publish.sh
@@ -109,10 +109,22 @@ echo "✅ npm install + npm test look good"
 # Confirm y/n (if running locally)
 ### TODO=====================
 
-# Publish with Dry Run
-echo_title "npm publish (dry-run)"
-npm publish --access public --dry-run
-echo "✅ Dry run looks good"
+# Stage once after building/testing; retain the legacy path for other consumers.
+PACKAGE_TARBALL=''
+if [ "${STAGE_PACKAGE:-false}" = 'true' ]; then
+	echo_title "Pack and validate staged npm artifact"
+	artifact_dir=$(mktemp -d "${TMPDIR:-/tmp}/npm-publish-artifact.XXXXXXXX")
+	trap 'rm -rf "$artifact_dir"' EXIT
+	script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+	PACKAGE_TARBALL=$(bash "$script_dir/../../npm-pack-staged/bin/pack.sh" "$PWD" "$artifact_dir" "latest" "${SMOKE_SCRIPT:-}")
+	npm publish "$PACKAGE_TARBALL" --access public --tag "latest" --dry-run --ignore-scripts --loglevel error
+else
+	# Publish with Dry Run
+	echo_title "npm publish (dry-run)"
+	npm publish --access public --dry-run
+	echo "✅ Dry run looks good"
+
+fi
 
 # Publish on GitHub and tag
 echo_title "Publishing a new release on GitHub and tagging"
@@ -126,8 +138,13 @@ if [ "${PROVENANCE}" = "true" ] && [ "${CI:-}" = "true" ] && [ "${GITHUB_ACTIONS
 	OPTIONS="${OPTIONS} --provenance"
 fi
 
-# shellcheck disable=SC2086 # We want to pass the options as multiple arguments
-npm publish ${OPTIONS}
+if [ -n "$PACKAGE_TARBALL" ]; then
+	# shellcheck disable=SC2086 # OPTIONS contains the existing publish flags.
+	npm publish "$PACKAGE_TARBALL" ${OPTIONS} --tag latest --ignore-scripts --loglevel error
+else
+	# shellcheck disable=SC2086 # OPTIONS contains the existing publish flags.
+	npm publish ${OPTIONS}
+fi
 echo "✅ Successfully published new '$NPM_VERSION_TYPE' release for $LOCAL_NAME as $LOCAL_VERSION"
 
 # Version bump to dev - create a branch and a PR, then merge
@@ -135,7 +152,7 @@ if [ "$LOCAL_BRANCH" == "$RELEASE_BRANCH" ] && [ "${SKIP_BUMP_TO_DEV:-}" != 'tru
 	echo_title "npm version (to next dev)"
 
 	NEXT_LOCAL_DEV_VERSION_TYPE="prepatch"
-	NEXT_LOCAL_DEV_VERSION=$( npm version --no-git-tag-version --preid "dev" "$NEXT_LOCAL_DEV_VERSION_TYPE" )
+	NEXT_LOCAL_DEV_VERSION=$( npm --silent version --no-git-tag-version --preid "dev" "$NEXT_LOCAL_DEV_VERSION_TYPE" )
 	echo "✅ Determined next local dev version: $NEXT_LOCAL_DEV_VERSION"
 
 	# Configure git


### PR DESCRIPTION
Bundled native dependencies can contain hard links created by node-gyp. npm preserves those links in the package archive, then the registry rejects publication with `E415: Hard link is not allowed`. This blocked VIP CLI 4.1.2.

Add an opt-in staged packaging path to the stable and prerelease publishing actions, plus a standalone `npm-pack-staged` action for recovery workflows. The helper runs preparation hooks before copying into a fresh directory with `rsync -a` (without `-H`), packs with scripts disabled, validates archive entries and package identity, and optionally runs a smoke script inside the extracted artifact. Dry-run and actual publication use that exact tarball with scripts disabled. Existing consumers retain the legacy path unless they enable `STAGE_PACKAGE`.

Scope silent logging to the version command whose stdout supplies the next development branch name. Staged publication keeps npm errors visible.

### Validation

- Seven regression tests passed, including both publisher scripts with publication mocked; verified matching tarball paths and SHA-256 hashes between dry-run and publication.
- Real VIP CLI 4.1.2 reproduction on Linux x64 / Node 24.20.0: original archive contained three hard links; staged archive contained none. All 14 CLI smoke tests passed against the extracted staged archive.
- ShellCheck, actionlint and diff checks passed. Added Ubuntu CI for regression tests.
- No actual npm publication performed.

### Integration

The companion VIP CLI change enables staging for stable releases, prereleases and recovery and pins this action commit. Land this shared-action change first. Publishing tarballs intentionally skips directory `publish`/`postpublish` hooks; consumers relying on those hooks must keep the legacy path or move that work into explicit workflow steps. Requires rsync and Python 3.

Companion workflow PR: https://github.com/Automattic/vip-cli/pull/3046.
